### PR TITLE
Add update-formula workflow (listens for v16 repository_dispatch)

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -1,0 +1,86 @@
+name: Update Homebrew Formula
+
+on:
+  repository_dispatch:
+    types: [formula-update]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to update formula to (e.g. 0.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tap
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ github.event.client_payload.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for npm package availability
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PKG="@testmuai/kane-cli"
+          echo "Waiting for ${PKG}@${VERSION} on npmjs.com..."
+          for i in $(seq 1 24); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              "https://registry.npmjs.org/${PKG}/${VERSION}")
+            if [ "$STATUS" = "200" ]; then
+              echo "${PKG}@${VERSION} is available."
+              exit 0
+            fi
+            echo "Poll ${i}/24 — HTTP ${STATUS}, sleeping 5s..."
+            sleep 5
+          done
+          echo "ERROR: ${PKG}@${VERSION} not visible on npmjs.com after 2m"
+          exit 1
+
+      - name: Compute tarball sha256
+        id: tarball
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TARBALL_URL="https://registry.npmjs.org/@testmuai/kane-cli/-/kane-cli-${VERSION}.tgz"
+
+          curl -fsSL "$TARBALL_URL" -o kane-cli.tgz
+          SHA256=$(sha256sum kane-cli.tgz | awk '{print $1}')
+
+          echo "tarball-url=${TARBALL_URL}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+          echo "Tarball: ${TARBALL_URL}"
+          echo "sha256:  ${SHA256}"
+
+      - name: Update formula
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TARBALL_URL="${{ steps.tarball.outputs.tarball-url }}"
+          SHA256="${{ steps.tarball.outputs.sha256 }}"
+          FORMULA="Formula/kane-cli.rb"
+
+          sed -i "s|^  url \".*\"|  url \"${TARBALL_URL}\"|" "$FORMULA"
+          sed -i "s|^  sha256 \".*\"|  sha256 \"${SHA256}\"|" "$FORMULA"
+          sed -i "s|^  version \".*\"|  version \"${VERSION}\"|" "$FORMULA"
+
+          echo "Updated formula to ${VERSION}:"
+          cat "$FORMULA"
+
+      - name: Commit and push
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/kane-cli.rb
+          git diff --cached --quiet && { echo "No changes to commit."; exit 0; }
+          git commit -m "Update kane-cli to ${VERSION}"
+          git push


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/update-formula.yml` to this tap.
- Triggers on `repository_dispatch` (type `formula-update`) from `LambdatestIncPrivate/v16` and manual `workflow_dispatch` for recovery.
- Workflow downloads the published npm tarball, computes `sha256`, and commits the bump to `Formula/kane-cli.rb` using the native `GITHUB_TOKEN` (no PAT).

## Context

Previously the formula lived in `LambdaTest/kane-cli` and the dispatch from v16 targeted that repo. That made the public tap unresolvable via `brew install LambdaTest/kane/kane-cli` because Homebrew expects the tap repo to be named `homebrew-<name>`.

After this PR:
- v16 will be updated (separate PR) to dispatch `LambdaTest/homebrew-kane` instead.
- `kane-cli` will have its `Formula/` dir and old workflow removed (separate PR).

## Merge order

1. **This PR** (non-breaking — just adds a listener)
2. v16 PR retargeting the dispatch
3. kane-cli PR removing the old formula + workflow

## Test plan

- [ ] After merge, run `gh workflow run update-formula.yml -f version=0.2.4 --repo LambdaTest/homebrew-kane` to verify a no-op bump (formula already at 0.2.4, so `git diff --cached --quiet` should exit cleanly).
- [ ] On the next real release, confirm v16 → this workflow → formula bump works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)