### PR TITLE
docs: add user-facing README for the tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # homebrew-kane
+
+Homebrew tap for [kane-cli](https://github.com/LambdaTest/kane-cli) — LambdaTest's KaneAI browser automation CLI.
+
+## Install
+
+```bash
+brew install LambdaTest/kane/kane-cli
+```
+
+Homebrew auto-resolves the tap on first use; no separate `brew tap` required.
+
+## Upgrade
+
+```bash
+brew upgrade kane-cli
+```
+
+## Uninstall
+
+```bash
+brew uninstall kane-cli
+brew untap LambdaTest/kane
+```
+
+## Supported platforms
+
+- macOS ARM64 (Apple Silicon)
+- Linux x64
+
+Intel Mac and ARM Linux binaries are not yet available.
+
+## Issues
+
+Please file bug reports and feature requests on the main CLI repo:
+https://github.com/LambdaTest/kane-cli/issues
+
+## License
+
+Apache-2.0 — see [LambdaTest/kane-cli](https://github.com/LambdaTest/kane-cli).


### PR DESCRIPTION
## Summary

Replaces the 15-byte stub (`# homebrew-kane`) with a proper README covering:

- The headline single-command install (`brew install LambdaTest/kane/kane-cli`)
- Upgrade and uninstall commands
- Supported platforms (macOS ARM64, Linux x64 — matches `Formula/kane-cli.rb` caveat)
- Pointer to `LambdaTest/kane-cli` for issue reporting (this repo is formula-only; no product code lives here)

## Why

The tap is now public and exposed to end users; the previous stub didn't tell them how to install. Since users typically land here from the `brew info` homepage or a search, giving them the canonical install command is the minimum bar.

## Test plan

- [ ] README renders correctly on the repo landing page
- [ ] All three `brew` commands in the README work against the live tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)