### PR TITLE
formula: depends_on cask: google-chrome + caveats refresh

### DIFF
--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -10,6 +10,7 @@ class KaneCli < Formula
   version "0.2.6"
 
   depends_on "node"
+  depends_on cask: "google-chrome"
 
   def install
     system "npm", "install", *std_npm_args
@@ -22,10 +23,10 @@ class KaneCli < Formula
     #    the one for the current platform; others are silently skipped.
     #
     # 2. The postinstall hook (scripts/install-chrome.cjs, ships with 0.3.0+)
-    #    downloads a pinned Chrome-for-Testing build to the user's cache dir
-    #    (~/.cache/kane-cli/chrome on macOS/Linux). Failures are non-fatal — see
-    #    KANE_CLI_SKIP_BROWSER_DOWNLOAD and KANE_CLI_CHROME_PATH in the caveats
-    #    below for opt-outs. Recovery: `brew reinstall LambdaTest/kane/kane-cli`.
+    #    verifies Google Chrome is present at /Applications/Google Chrome.app
+    #    and prints install instructions otherwise. With the cask depends_on
+    #    above, brew has already installed Chrome by the time the hook runs,
+    #    so the check passes silently. The hook is fail-soft regardless.
   end
 
   def caveats
@@ -33,17 +34,12 @@ class KaneCli < Formula
       Currently supported platforms: macOS ARM64 (Apple Silicon) and Linux x64.
       Intel Mac and ARM Linux binaries are not yet available.
 
-      On first install, kane-cli downloads a known-good Chrome-for-Testing build
-      (~150 MB) to ~/.cache/kane-cli/chrome. Subsequent installs reuse the cache.
+      kane-cli requires Google Chrome at /Applications/Google Chrome.app.
+      Homebrew installs it automatically via the `google-chrome` cask
+      declared as a dependency.
 
-      Skip the Chrome download (CI / air-gapped environments):
-        KANE_CLI_SKIP_BROWSER_DOWNLOAD=1 brew install LambdaTest/kane/kane-cli
-
-      Use an existing Chrome binary instead:
-        KANE_CLI_CHROME_PATH=/path/to/chrome brew install LambdaTest/kane/kane-cli
-
-      The Chrome cache survives `brew uninstall`. Remove it manually with:
-        rm -rf ~/.cache/kane-cli
+      To use an existing Chrome at a non-standard path:
+        export KANE_CLI_CHROME_PATH=/path/to/chrome
     EOS
   end
 

--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -25,7 +25,7 @@ class KaneCli < Formula
     #    downloads a pinned Chrome-for-Testing build to the user's cache dir
     #    (~/.cache/kane-cli/chrome on macOS/Linux). Failures are non-fatal — see
     #    KANE_CLI_SKIP_BROWSER_DOWNLOAD and KANE_CLI_CHROME_PATH in the caveats
-    #    below for opt-outs. Recovery: `kane-cli doctor --install-browser`.
+    #    below for opt-outs. Recovery: `brew reinstall LambdaTest/kane/kane-cli`.
   end
 
   def caveats

--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -16,17 +16,14 @@ class KaneCli < Formula
     system "npm", "install", *std_npm_args
     bin.install_symlink libexec.glob("bin/*")
 
-    # `npm install` triggers two automatic behaviors here:
+    # `npm install` resolves the optionalDependencies block in the meta package
+    # (@testmuai/kane-cli-{darwin-arm64,linux-x64,win-x64}) and pulls only the
+    # platform-specific native runner binary; others are silently skipped.
     #
-    # 1. optionalDependencies resolves to the matching platform binary package
-    #    (@testmuai/kane-cli-{darwin-arm64,linux-x64,win-x64}). npm installs only
-    #    the one for the current platform; others are silently skipped.
-    #
-    # 2. The postinstall hook (scripts/install-chrome.cjs, ships with 0.3.0+)
-    #    verifies Google Chrome is present at /Applications/Google Chrome.app
-    #    and prints install instructions otherwise. With the cask depends_on
-    #    above, brew has already installed Chrome by the time the hook runs,
-    #    so the check passes silently. The hook is fail-soft regardless.
+    # Chrome is installed by `depends_on cask: "google-chrome"` above, before
+    # this block runs. kane-cli verifies Chrome is reachable at runtime via
+    # the gate in src/orchestration/prepare-chrome.ts — produces a clean
+    # actionable error if Chrome is missing or moved.
   end
 
   def caveats

--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -15,16 +15,35 @@ class KaneCli < Formula
     system "npm", "install", *std_npm_args
     bin.install_symlink libexec.glob("bin/*")
 
-    # The npm meta package declares optionalDependencies on platform-specific
-    # native binary packages (@testmuai/kane-cli-{darwin-arm64,linux-x64,win-x64}).
-    # npm installs only the matching one for the current platform — the others
-    # are silently skipped and never present, so no cleanup is required here.
+    # `npm install` triggers two automatic behaviors here:
+    #
+    # 1. optionalDependencies resolves to the matching platform binary package
+    #    (@testmuai/kane-cli-{darwin-arm64,linux-x64,win-x64}). npm installs only
+    #    the one for the current platform; others are silently skipped.
+    #
+    # 2. The postinstall hook (scripts/install-chrome.cjs, ships with 0.3.0+)
+    #    downloads a pinned Chrome-for-Testing build to the user's cache dir
+    #    (~/.cache/kane-cli/chrome on macOS/Linux). Failures are non-fatal — see
+    #    KANE_CLI_SKIP_BROWSER_DOWNLOAD and KANE_CLI_CHROME_PATH in the caveats
+    #    below for opt-outs. Recovery: `kane-cli doctor --install-browser`.
   end
 
   def caveats
     <<~EOS
       Currently supported platforms: macOS ARM64 (Apple Silicon) and Linux x64.
       Intel Mac and ARM Linux binaries are not yet available.
+
+      On first install, kane-cli downloads a known-good Chrome-for-Testing build
+      (~150 MB) to ~/.cache/kane-cli/chrome. Subsequent installs reuse the cache.
+
+      Skip the Chrome download (CI / air-gapped environments):
+        KANE_CLI_SKIP_BROWSER_DOWNLOAD=1 brew install LambdaTest/kane/kane-cli
+
+      Use an existing Chrome binary instead:
+        KANE_CLI_CHROME_PATH=/path/to/chrome brew install LambdaTest/kane/kane-cli
+
+      The Chrome cache survives `brew uninstall`. Remove it manually with:
+        rm -rf ~/.cache/kane-cli
     EOS
   end
 


### PR DESCRIPTION
## Summary

Adds `depends_on cask: "google-chrome"` to the formula so `brew install LambdaTest/kane/kane-cli` automatically installs Chrome to `/Applications/Google Chrome.app/...` before the `npm install` step runs. No more manual Chrome setup for brew users.

Caveats refreshed to describe the dependency and the `KANE_CLI_CHROME_PATH` escape hatch for users with Chrome at non-standard locations. Install-block comment refreshed to mention the runtime gate that kane-cli uses to verify Chrome at run time.

## Files changed (1, +16 / -4)

`Formula/kane-cli.rb`:
- Added `depends_on cask: "google-chrome"`.
- Updated `caveats` block.
- Updated install-block comment.
- `url` / `sha256` / `version` untouched (auto-managed by `update-formula.yml` on each release).

## Pairs with

- [LambdatestIncPrivate/v16#446](https://github.com/LambdatestIncPrivate/v16/pull/446) — runtime Chrome gate.
- [LambdaTest/kane-cli#12](https://github.com/LambdaTest/kane-cli/pull/12) — README documents Chrome prerequisite.

## Test plan

- [ ] `brew install LambdaTest/kane/kane-cli` on a machine without Chrome installs Chrome via the cask, then kane-cli, with no manual steps.
- [ ] `brew test kane-cli` still passes (`--version` doesn't need Chrome).
- [ ] On a machine with Chrome already present, brew sees the cask is satisfied and skips re-install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)