### PR TITLE
fix: strip --build-from-source from std_npm_args (resolves Xcode compile error)

### DIFF
--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -12,7 +12,15 @@ class KaneCli < Formula
   depends_on "node"
 
   def install
-    system "npm", "install", *std_npm_args
+    # Strip --build-from-source from std_npm_args. Brew injects this flag
+    # unconditionally (Library/Homebrew/language/node.rb), which forces every
+    # native dep to compile via node-gyp. kane-cli pulls in `sharp`, whose
+    # libvips bindings need a current macOS SDK; on machines with an older
+    # Xcode (e.g. 16.x on macOS 26) the compile blows up with brew's
+    # "Your Xcode is too outdated" hard-fail. Letting npm install the
+    # `@img/sharp-{platform}` prebuilt instead avoids any compilation.
+    args = std_npm_args.reject { |arg| arg == "--build-from-source" }
+    system "npm", "install", *args
     bin.install_symlink libexec.glob("bin/*")
 
     # The npm meta package declares optionalDependencies on platform-specific


### PR DESCRIPTION
## The bug

`brew install LambdaTest/kane/kane-cli` fails on macOS 26 with Xcode 16.x:

```
Error: Your Xcode (16.4) at /Applications/Xcode.app is too outdated.
Please update to Xcode 26.3 (or delete it).
```

Other LambdaTest formulas without native deps (e.g. `browser-agent`) install fine on the same machine — proving the issue is specific to this formula.

## Root cause

Brew's `std_npm_args` ([source](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/language/node.rb)) injects `--build-from-source` unconditionally:

```ruby
args = %W[
  --loglevel=silly
  --global
  --build-from-source     ← culprit
  --min-release-age=1
  --#{npm_cache_config}
  --prefix=#{libexec}
  ...
]
```

Chain of failure for kane-cli specifically:

1. brew runs `npm install --build-from-source ...`
2. `sharp@^0.34.5` (transitive dep of `@testmuai/kane-cli`) sees the flag → **skips its `@img/sharp-{platform}` prebuilt** detection.
3. Falls through to `npm run build` → node-gyp compile of libvips bindings.
4. node-gyp invokes `clang` against the macOS 26 SDK.
5. Xcode 16.4 ships an SDK older than macOS 26 supports → brew preempts with the "Your Xcode is too outdated" hard-fail.

## The fix

Filter `--build-from-source` out of `std_npm_args` before passing to `npm install`:

```ruby
args = std_npm_args.reject { |arg| arg == "--build-from-source" }
system "npm", "install", *args
```

Lets npm install `@img/sharp-darwin-arm64` (or the matching platform prebuilt) instead of compiling from source. No source compile = no SDK requirement = no Xcode error.

## Why not just install Chrome differently or hack around brew

This is a brew-formula bug specific to npm formulas with native deps. The `--build-from-source` injection appears intended for "pure brew" formulas where source-building is the expected path, but for npm meta packages whose native bits ship as `optionalDependencies` of upstream packages (the modern sharp/playwright/esbuild pattern), the flag is actively harmful.

`std_npm_args.reject { |arg| arg == "--build-from-source" }` is the minimum-blast-radius workaround. Doesn't change any other brew behavior; doesn't change kane-cli's published npm package; doesn't require users to do anything.

## Verification plan

- [ ] `brew uninstall kane-cli` (if installed)
- [ ] `brew install LambdaTest/kane/kane-cli` from this branch — should complete on macOS 26 + Xcode 16.x without the Xcode error.
- [ ] `kane-cli --version` prints `0.2.7`.
- [ ] Inspect `libexec/lib/node_modules/@testmuai/kane-cli/node_modules/@img/` — should contain `sharp-darwin-arm64/` (the prebuilt), confirming source compile was avoided.
- [ ] On a machine with current Xcode, install behavior unchanged (prebuilt path is the same regardless of Xcode state).

## Independent of #3

This is a separate, urgent fix for the live formula. PR #3 (Chrome cask + caveats refresh) is unrelated and remains open for its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)