### PR TITLE
fix: declare bottle :unneeded to skip brew's Xcode pre-install check

### DIFF
--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -9,16 +9,25 @@ class KaneCli < Formula
   license "Apache-2.0"
   version "0.2.7"
 
+  # No source compilation — the install step just pulls a precompiled npm
+  # package (with platform-specific prebuilt sub-packages) and symlinks the
+  # bin entry. Declaring `bottle :unneeded` skips brew's build-environment
+  # setup, which otherwise runs `fatal_setup_build_environment_checks` and
+  # hard-fails with "Your Xcode is too outdated" on machines whose Xcode
+  # is older than the current macOS SDK requires (e.g. Xcode 16.x on
+  # macOS 26). brew/Library/Homebrew/extend/os/mac/diagnostic.rb#L236.
+  bottle :unneeded
+
   depends_on "node"
 
   def install
-    # Strip --build-from-source from std_npm_args. Brew injects this flag
-    # unconditionally (Library/Homebrew/language/node.rb), which forces every
-    # native dep to compile via node-gyp. kane-cli pulls in `sharp`, whose
-    # libvips bindings need a current macOS SDK; on machines with an older
-    # Xcode (e.g. 16.x on macOS 26) the compile blows up with brew's
-    # "Your Xcode is too outdated" hard-fail. Letting npm install the
-    # `@img/sharp-{platform}` prebuilt instead avoids any compilation.
+    # Strip --build-from-source from std_npm_args (brew/Library/Homebrew/
+    # language/node.rb injects it unconditionally). For sharp specifically,
+    # this forces compilation via node-gyp instead of using the platform
+    # prebuilt — which also tries to invoke the toolchain. With `bottle
+    # :unneeded` above, the build env isn't set up at all, but the flag
+    # would still steer sharp toward source on machines that DO have a
+    # current toolchain. Strip it to keep behavior consistent.
     args = std_npm_args.reject { |arg| arg == "--build-from-source" }
     system "npm", "install", *args
     bin.install_symlink libexec.glob("bin/*")


### PR DESCRIPTION
## Why this is still failing after #4

After [#4](https://github.com/LambdaTest/homebrew-kane/pull/4) merged, users on macOS 26 + Xcode 16.x still see:

```
==> Installing kane-cli from lambdatest/kane
Error: Your Xcode (16.4) at /Applications/Xcode.app is too outdated.
Please update to Xcode 26.3 (or delete it).
```

Notice the error fires **immediately after** "Installing kane-cli from lambdatest/kane" — **before** any of the `def install` steps run. PR #4 fixed a real downstream issue (sharp falling through to source compile), but the Xcode error is from a **different, earlier** check in brew.

## Where the error actually comes from

Tracing brew source:

- `Library/Homebrew/extend/os/mac/diagnostic.rb#L236` — `check_xcode_minimum_version`:
  ```ruby
  def check_xcode_minimum_version
    return unless MacOS::Xcode.below_minimum_version?
    <<~EOS
      Your Xcode (#{xcode}) at #{MacOS::Xcode.bundle_path} is too outdated.
      Please update to Xcode #{MacOS::Xcode.latest_version} (or delete it).
      ...
  ```
- It's part of `fatal_setup_build_environment_checks`, invoked from `Library/Homebrew/extend/os/mac/extend/ENV/{std,super}.rb` whenever brew sets up a build environment for a formula.
- Brew sets up the build environment **only when the formula is installed from source** (no usable bottle).

The `kane-cli` formula has no `bottle do` block → brew treats every install as source-build → triggers `setup_build_environment` → fires `check_xcode_minimum_version` → hard-fails before `def install` runs.

`browser-agent` and other LambdaTest formulas install fine because they either provide bottles or declare `:unneeded`.

## The fix: `bottle :unneeded`

Declares "this formula doesn't need a build environment." Skips `setup_build_environment` entirely. The Xcode minimum-version check never runs.

```ruby
bottle :unneeded
```

This is the canonical brew syntax for npm-installed and similar formulas where the install step doesn't compile anything — it just downloads precompiled artifacts and creates symlinks. Confirmed still supported in current brew (rubocop tests reference it explicitly).

## Why PR #4's `--build-from-source` strip is still needed

Both changes target different layers and complement each other:

| Layer | Without it | With it |
|---|---|---|
| `bottle :unneeded` | brew's pre-install Xcode check fires → hard-fail | check skipped → install proceeds |
| Strip `--build-from-source` | sharp tries to compile via node-gyp → second failure (different error) | sharp uses `@img/sharp-darwin-arm64` prebuilt → no compile attempt |

If we kept only `bottle :unneeded`, sharp would still try to compile (just hitting node-gyp's clang SDK error instead of brew's Xcode pre-check). Keeping both gives a clean install path on machines with old/new/no Xcode alike.

## Verification plan

After merge:

```bash
brew uninstall kane-cli 2>/dev/null
brew untap lambdatest/kane 2>/dev/null
brew install LambdaTest/kane/kane-cli
kane-cli --version  # should print 0.2.7
```

Expected: completes without the Xcode error, on machines with any Xcode state (current, outdated, or absent). On a machine with **no** Xcode and **no** CLT, `bottle :unneeded` still skips the env setup, but `npm install` may need basic CLT for `node-gyp` shims. Worth flagging — almost everyone has CLT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)