### PR TITLE
revert: remove broken `bottle :unneeded` directive

### DIFF
--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -9,33 +9,16 @@ class KaneCli < Formula
   license "Apache-2.0"
   version "0.2.7"
 
-  # No source compilation — the install step just pulls a precompiled npm
-  # package (with platform-specific prebuilt sub-packages) and symlinks the
-  # bin entry. Declaring `bottle :unneeded` skips brew's build-environment
-  # setup, which otherwise runs `fatal_setup_build_environment_checks` and
-  # hard-fails with "Your Xcode is too outdated" on machines whose Xcode
-  # is older than the current macOS SDK requires (e.g. Xcode 16.x on
-  # macOS 26). brew/Library/Homebrew/extend/os/mac/diagnostic.rb#L236.
-  bottle :unneeded
-
   depends_on "node"
 
   def install
     # Strip --build-from-source from std_npm_args (brew/Library/Homebrew/
-    # language/node.rb injects it unconditionally). For sharp specifically,
-    # this forces compilation via node-gyp instead of using the platform
-    # prebuilt — which also tries to invoke the toolchain. With `bottle
-    # :unneeded` above, the build env isn't set up at all, but the flag
-    # would still steer sharp toward source on machines that DO have a
-    # current toolchain. Strip it to keep behavior consistent.
+    # language/node.rb injects it unconditionally). For sharp, that flag
+    # forces a node-gyp compile instead of using the prebuilt — which
+    # invokes the toolchain. Strip it so install stays toolchain-free.
     args = std_npm_args.reject { |arg| arg == "--build-from-source" }
     system "npm", "install", *args
     bin.install_symlink libexec.glob("bin/*")
-
-    # The npm meta package declares optionalDependencies on platform-specific
-    # native binary packages (@testmuai/kane-cli-{darwin-arm64,linux-x64,win-x64}).
-    # npm installs only the matching one for the current platform — the others
-    # are silently skipped and never present, so no cleanup is required here.
   end
 
   def caveats


### PR DESCRIPTION
## Why

PR #5 added `bottle :unneeded`, but that directive was removed in modern Homebrew. `bottle` now takes zero arguments, so the formula errors out on load with:

```
Error: lambdatest/kane/kane-cli: wrong number of arguments (given 1, expected 0)
```

`brew install` is fully broken on main as a result.

## What this does

Removes the line. Restores PR #4 state (sharp `--build-from-source` strip retained — that fix is independent and still useful).

## What it does NOT fix

The original Xcode-too-old failure on macOS 26 that PR #5 was trying to dodge. That requires a real bottle so brew never enters the build environment. Recommended path:

1. Add a CI workflow that runs `brew install --build-bottle` on a current macOS runner (macos-15 / 26 with current Xcode) and a Linux runner.
2. Upload the resulting `*.bottle.tar.gz` to a GitHub Release at `homebrew-kane/releases/download/kane-cli-<version>`.
3. Add a `bottle do` block to the formula referencing those artifacts:
   ```ruby
   bottle do
     root_url "https://github.com/LambdaTest/homebrew-kane/releases/download/kane-cli-0.2.7"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "<sha>"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "<sha>"
   end
   ```

After that, `brew install` downloads the prebuilt bottle on user machines — Xcode/CLT version becomes irrelevant.

## Test

`brew install LambdaTest/kane/kane-cli` should at minimum load the formula (won't error on the bottle line). On machines with current Xcode it'll work end-to-end.