### PR TITLE
ci: split Intel bottle into background pipeline

### DIFF
--- a/.github/workflows/build-bottle-intel.yml
+++ b/.github/workflows/build-bottle-intel.yml
@@ -1,0 +1,211 @@
+name: Build bottle (Intel macOS)
+
+# Builds the Intel x86_64 macOS bottle (`ventura`) in a workflow
+# *separate* from the main "Build bottles" pipeline, because GHA's
+# `macos-13` (last free Intel pool) queues for 30+ min — sometimes
+# hours — before runner allocation. Including it in the main matrix
+# blocks the entire publish on Intel availability.
+#
+# Decoupling means:
+#   - The main pipeline ships fast (~5–10 min) with the 4 well-allocated
+#     runners (sequoia / sonoma / latest / linux).
+#   - This workflow fires off "Build bottles" success and runs in the
+#     background until macos-13 finally allocates, builds the ventura
+#     bottle, uploads it to the existing release, and patches the
+#     formula's bottle block to add a `ventura` row.
+#
+# Side effects of the asymmetric timing:
+#   - Tahoe / Apple Silicon / Linux users get bottles immediately on
+#     release.
+#   - Intel users hit `npm install` source build until this workflow
+#     finishes — usually within an hour or two, sometimes longer.
+#     That's a slowness regression vs an arm64 user pouring a bottle,
+#     not a breakage.
+
+on:
+  workflow_run:
+    workflows: ["Build bottles"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Formula version to (re)build the Intel bottle for. Leave blank to use whatever's in Formula/kane-cli.rb on main."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  guard:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.read.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Resolve version and verify release exists
+        id: read
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION=$(grep '^  version' Formula/kane-cli.rb | awk -F'"' '{print $2}')
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # If main hasn't published yet, the release won't exist and
+          # there's nowhere to upload — bail with a clear message.
+          if ! gh release view "kane-cli-${VERSION}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release kane-cli-${VERSION} does not exist yet. Has 'Build bottles' published?"
+            exit 1
+          fi
+
+  build:
+    needs: guard
+    runs-on: macos-13
+    # Counts from runner allocation, not queue. Queue time is unbounded
+    # (capped by GHA's 24h max). Once a runner *does* pick up the job,
+    # 30 min is plenty for build + upload + commit.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+
+      - name: Tap self into Homebrew
+        run: |
+          TAP_DIR="$(brew --repository)/Library/Taps/lambdatest/homebrew-kane"
+          mkdir -p "$(dirname "$TAP_DIR")"
+          ln -snf "$GITHUB_WORKSPACE" "$TAP_DIR"
+          brew tap | grep lambdatest/kane
+
+      - name: Pre-install node dependency
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: brew install node
+
+      - name: Build bottle
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          VERSION="${{ needs.guard.outputs.version }}"
+          ROOT_URL="https://github.com/${{ github.repository }}/releases/download/kane-cli-${VERSION}"
+
+          brew install --build-bottle lambdatest/kane/kane-cli
+          brew bottle \
+            --no-rebuild \
+            --json \
+            --root-url="${ROOT_URL}" \
+            lambdatest/kane/kane-cli
+
+          for f in kane-cli--*.bottle.*; do
+            [ -e "$f" ] || continue
+            mv "$f" "${f/--/-}"
+          done
+
+          ls -la kane-cli-*.bottle.* || true
+
+      - name: Upload bottle to existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.guard.outputs.version }}"
+          gh release upload "kane-cli-${VERSION}" \
+            kane-cli-*.bottle.tar.gz --clobber
+
+      - name: Patch formula with full bottle set
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The main publish job may have committed the bottle block while
+          # we were queued. Pull latest main before patching.
+          git fetch origin main
+          git reset --hard origin/main
+
+          # Skip if the formula has moved on to a newer version while we
+          # were waiting for an Intel runner. The release tag for our
+          # version is still valid (we already uploaded), but patching
+          # the current formula with old shas would be wrong.
+          CURRENT=$(grep '^  version' Formula/kane-cli.rb | awk -F'"' '{print $2}')
+          if [ "$CURRENT" != "$VERSION" ]; then
+            echo "Formula has moved on to ${CURRENT} (we built for ${VERSION}). Skipping formula patch."
+            echo "The ventura bottle is uploaded to release kane-cli-${VERSION} and remains usable for that version."
+            exit 0
+          fi
+
+          # Download every bottle from the release so we regenerate the
+          # block from ground truth instead of blindly splicing a new row.
+          mkdir -p bottles
+          gh release download "kane-cli-${VERSION}" \
+            -p '*.bottle.tar.gz' -D bottles --clobber
+
+          python3 - <<'PY'
+          import hashlib, glob, os, re, sys
+
+          version = os.environ["VERSION"]
+          shas = {}
+          for f in sorted(glob.glob(f"bottles/kane-cli-{version}.*.bottle.tar.gz")):
+              m = re.search(rf"kane-cli-{re.escape(version)}\.([^.]+)\.bottle\.tar\.gz$", f)
+              if not m:
+                  continue
+              label = m.group(1)
+              with open(f, "rb") as fp:
+                  shas[label] = hashlib.sha256(fp.read()).hexdigest()
+
+          if not shas:
+              sys.exit("No bottle artifacts found in release")
+
+          macos_rank = {"tahoe": 0, "sequoia": 1, "sonoma": 2, "ventura": 3, "monterey": 4}
+          def sort_key(label):
+              if label == "x86_64_linux":
+                  return (3, 0, label)
+              if label.startswith("arm64_"):
+                  name = label[len("arm64_"):]
+                  return (0, macos_rank.get(name, 99), label)
+              return (1, macos_rank.get(label, 99), label)
+          ordered = sorted(shas.keys(), key=sort_key)
+
+          root_url = f"https://github.com/LambdaTest/homebrew-kane/releases/download/kane-cli-{version}"
+          width = max(len(k) for k in ordered) + 1
+          lines = ["  bottle do", f'    root_url "{root_url}"']
+          for label in ordered:
+              lines.append(
+                  f'    sha256 cellar: :any_skip_relocation, {label}:{" " * (width - len(label))}"{shas[label]}"'
+              )
+          lines.append("  end")
+          block = "\n".join(lines) + "\n"
+
+          with open("Formula/kane-cli.rb") as f:
+              src = f.read()
+          src = re.sub(r"  bottle do\n(?:.*\n)*?  end\n+", "", src)
+          src, n = re.subn(
+              r'(  version "[^"]+"\n)\n*',
+              r"\1\n" + block + "\n",
+              src,
+              count=1,
+          )
+          if n != 1:
+              sys.exit("Could not locate version line for bottle block insertion")
+          with open("Formula/kane-cli.rb", "w") as f:
+              f.write(src)
+          print(src)
+          PY
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/kane-cli.rb
+          if git diff --cached --quiet; then
+            echo "Formula bottle block already current."
+            exit 0
+          fi
+          git commit -m "Add ventura bottle for kane-cli ${VERSION}"
+          git push origin main

--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -61,7 +61,6 @@ jobs:
         # Coverage today:
         #   macos-15      → arm64_sequoia    (Apple Silicon, macOS 15)
         #   macos-14      → arm64_sonoma     (Apple Silicon, macOS 14)
-        #   macos-13      → ventura          (Intel x86_64, macOS 13)
         #   macos-latest  → whatever GHA's "latest" alias points at
         #                  (currently arm64_sonoma — duplicates macos-14;
         #                  kept as forward-compat: when GHA promotes
@@ -69,6 +68,16 @@ jobs:
         #   ubuntu-latest → x86_64_linux
         #
         # Not covered:
+        #   ventura       — Intel x86_64. `macos-13` is GHA's last free Intel
+        #                   pool, deprecating, and queues for 30+ min before
+        #                   allocation. Adding it gates the entire publish
+        #                   on Intel availability, which means waiting hours
+        #                   per release. Intel users still install fine —
+        #                   brew falls back to source build (npm install)
+        #                   when no matching bottle is published. Re-add
+        #                   only if (a) Intel queue improves, or (b) we move
+        #                   to `macos-13-large` (paid) on a split workflow
+        #                   that doesn't gate the main publish.
         #   arm64_tahoe   — GHA doesn't ship `macos-26` runners yet. brew's
         #                   bottle fallback should pick arm64_sequoia on
         #                   Tahoe in practice. Add `macos-26` here when GHA
@@ -79,7 +88,6 @@ jobs:
         os:
           - macos-15
           - macos-14
-          - macos-13
           - macos-latest
           - ubuntu-latest
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Why

GHA's `macos-13` (last free Intel x86_64 pool) queues for 30+ minutes — sometimes hours — before allocating a runner. Including it in the main bottle matrix gates the entire publish on Intel availability:

- Run [25064114819](https://github.com/LambdaTest/homebrew-kane/actions/runs/25064114819): 4 of 5 builds went green in ~5 min, macos-13 was still queued ~10 min later with no runner allocated. We cancelled.

We don't want Tahoe / Apple Silicon / Linux users waiting for Intel to allocate before they can `brew install`.

## What this PR does

**Two commits on the same branch.**

### 1. Drop `macos-13` from the main matrix

Main "Build bottles" workflow now ships fast on:
- `macos-15` → `arm64_sequoia`
- `macos-14` → `arm64_sonoma`
- `macos-latest` → forward-compat (currently arm64_sonoma, auto-bumps when GHA promotes the alias)
- `ubuntu-latest` → `x86_64_linux`

### 2. Add a new workflow: `Build bottle (Intel macOS)`

Runs on its own:
- **Triggers** off `Build bottles` success (`workflow_run`), or `workflow_dispatch` for manual.
- **Verifies** the release exists before queueing the Intel job (no point if main hasn't published).
- **Builds** the `ventura` bottle on macos-13 — sits in queue however long Intel takes.
- **Uploads** to the existing `kane-cli-<version>` release.
- **Re-downloads** the full bottle set from that release and regenerates the formula's bottle block from ground truth (so all four other shas stay correct), now including `ventura`.
- **Pulls latest main** before patching to handle the case where main's publish job committed in the meantime.
- **Skips formula patch** if the formula has moved on to a newer version while we were queued — the bottle is still usable for the version it was built for, brew resolves by tag, not by current formula state.

## Net behavior

| User segment | Bottle availability after release |
|---|---|
| Apple Silicon Sequoia / Tahoe | immediate (~5 min after npm publish) |
| Apple Silicon Sonoma | immediate |
| Linux x64 | immediate |
| Intel x86_64 (Ventura) | whenever GHA's Intel queue clears — usually within 1–2h, occasionally longer. Until then, Intel users hit the npm source-build path (which works fine on Ventura with current Xcode). |

## Test plan

- [ ] Merge → manual `workflow_dispatch` on **Build bottles** for `0.2.7` to backfill the four fast bottles.
- [ ] On main pipeline success, confirm **Build bottle (Intel macOS)** auto-fires via `workflow_run`.
- [ ] (Possibly hours later) confirm the Intel run completes, uploads `kane-cli-0.2.7.ventura.bottle.tar.gz` to the release, and commits a formula update with the `ventura` row added.
- [ ] If you want to skip waiting for Intel, force-merge after the main pipeline succeeds — the Intel workflow can be retriggered later via `workflow_dispatch` once a runner is around.