### PR TITLE
fix: install platform optional dep so v16-runner is present

### DIFF
--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -9,12 +9,10 @@ class KaneCli < Formula
   license "Apache-2.0"
   version "0.2.7"
 
-  bottle do
-    root_url "https://github.com/LambdaTest/homebrew-kane/releases/download/kane-cli-0.2.7"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7cf5cded5e6e0eed67d5be76e6e0b3b9e895d7a422add2d3d30625615ee19e17"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4b4e61f6e38d4b911b652ad7018a86d10ad17d4f102daa65b5194e1985116e7c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2cf64adeb2deaa709baa276026e5bbe12795d596e200461aacfd66516524c48d"
-  end
+  # Bottle block intentionally removed — the previously published bottles
+  # ship without the v16-runner binary (platform optional dep was missing
+  # from the brew install). Build bottles workflow will repopulate this
+  # block once the install fix below is merged.
 
   depends_on "node"
 
@@ -25,6 +23,36 @@ class KaneCli < Formula
     # invokes the toolchain. Strip it so install stays toolchain-free.
     args = std_npm_args.reject { |arg| arg == "--build-from-source" }
     system "npm", "install", *args
+
+    # Install the platform-specific optional dep that ships v16-runner.
+    # brew's `--prefix=#{libexec}` mode behaves like a global install and
+    # modern npm skips `optionalDependencies` in that mode, so the platform
+    # subpackage (@testmuai/kane-cli-<plat>) is missing after the main
+    # install — kane-cli then can't find v16-runner at runtime.
+    #
+    # Install it explicitly into the main package's nested node_modules so
+    # the runtime resolver finds it via the first probed path (`<pkg>/dist
+    # /../node_modules/<plat-pkg>/bin/v16-runner`). brew's --ignore-scripts
+    # also blocks the platform pkg's postinstall (which chmods the binary),
+    # so chmod here ourselves.
+    platform_pkg =
+      if OS.mac?
+        Hardware::CPU.arm? ? "@testmuai/kane-cli-darwin-arm64" : "@testmuai/kane-cli-darwin-x64"
+      elsif OS.linux?
+        "@testmuai/kane-cli-linux-x64"
+      end
+
+    if platform_pkg
+      pkg_dir = libexec/"lib/node_modules/@testmuai/kane-cli"
+      cd pkg_dir do
+        system "npm", "install", "--no-save",
+               "--cache=#{HOMEBREW_CACHE}/npm_cache",
+               "#{platform_pkg}@#{version}"
+      end
+      runner = pkg_dir/"node_modules/#{platform_pkg}/bin/v16-runner"
+      chmod 0755, runner if runner.exist?
+    end
+
     bin.install_symlink libexec.glob("bin/*")
   end
 
@@ -37,5 +65,17 @@ class KaneCli < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/kane-cli --version")
+    # Smoke-test the v16-runner binary is present and executable. Without
+    # this, `kane-cli --version` passes (it's pure JS) but `kane-cli run`
+    # throws `v16-runner not found`. See git history for the regression.
+    runner_pkg =
+      if OS.mac?
+        Hardware::CPU.arm? ? "@testmuai/kane-cli-darwin-arm64" : "@testmuai/kane-cli-darwin-x64"
+      elsif OS.linux?
+        "@testmuai/kane-cli-linux-x64"
+      end
+    runner = libexec/"lib/node_modules/@testmuai/kane-cli/node_modules/#{runner_pkg}/bin/v16-runner"
+    assert_predicate runner, :exist?, "v16-runner binary missing — platform pkg #{runner_pkg} not installed"
+    assert_predicate runner, :executable?, "v16-runner not executable — postinstall chmod missed"
   end
 end

--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -11,8 +11,10 @@ class KaneCli < Formula
 
   # Bottle block intentionally removed — the previously published bottles
   # ship without the v16-runner binary (platform optional dep was missing
-  # from the brew install). Build bottles workflow will repopulate this
-  # block once the install fix below is merged.
+  # from the brew install). The `.github/workflows/build-bottles.yml`
+  # pipeline rebuilds bottles and rewrites this block when re-run after
+  # this fix lands. Until then brew falls back to source build, which is
+  # correct with the install changes below.
 
   depends_on "node"
 
@@ -35,23 +37,34 @@ class KaneCli < Formula
     # /../node_modules/<plat-pkg>/bin/v16-runner`). brew's --ignore-scripts
     # also blocks the platform pkg's postinstall (which chmods the binary),
     # so chmod here ourselves.
+    # Hardware::CPU.arm? is true on Linux aarch64 too — gate Linux on
+    # `intel?` so we don't try to install an x64 binary on linux-arm64.
     platform_pkg =
       if OS.mac?
         Hardware::CPU.arm? ? "@testmuai/kane-cli-darwin-arm64" : "@testmuai/kane-cli-darwin-x64"
-      elsif OS.linux?
+      elsif OS.linux? && Hardware::CPU.intel?
         "@testmuai/kane-cli-linux-x64"
       end
 
-    if platform_pkg
-      pkg_dir = libexec/"lib/node_modules/@testmuai/kane-cli"
-      cd pkg_dir do
-        system "npm", "install", "--no-save",
-               "--cache=#{HOMEBREW_CACHE}/npm_cache",
-               "#{platform_pkg}@#{version}"
-      end
-      runner = pkg_dir/"node_modules/#{platform_pkg}/bin/v16-runner"
-      chmod 0755, runner if runner.exist?
+    # Match the caveats: kane-cli is unusable without v16-runner, so fail
+    # loudly at install time on platforms that don't ship one rather than
+    # producing a silent broken install.
+    odie "kane-cli does not yet ship a v16-runner binary for this platform." if platform_pkg.nil?
+
+    pkg_dir = libexec/"lib/node_modules/@testmuai/kane-cli"
+    cd pkg_dir do
+      # Mirror brew's tightened npm flags (--ignore-scripts, --audit/fund off)
+      # so this second install matches the security/sandbox stance of the
+      # first. We chmod the binary ourselves below, so blocking the pkg's
+      # postinstall is fine.
+      system "npm", "install", "--no-save",
+             "--ignore-scripts", "--audit=false", "--fund=false",
+             "--loglevel=error",
+             "--cache=#{HOMEBREW_CACHE}/npm_cache",
+             "#{platform_pkg}@#{version}"
     end
+    runner = pkg_dir/"node_modules/#{platform_pkg}/bin/v16-runner"
+    chmod 0755, runner if runner.exist?
 
     bin.install_symlink libexec.glob("bin/*")
   end
@@ -71,7 +84,7 @@ class KaneCli < Formula
     runner_pkg =
       if OS.mac?
         Hardware::CPU.arm? ? "@testmuai/kane-cli-darwin-arm64" : "@testmuai/kane-cli-darwin-x64"
-      elsif OS.linux?
+      elsif OS.linux? && Hardware::CPU.intel?
         "@testmuai/kane-cli-linux-x64"
       end
     runner = libexec/"lib/node_modules/@testmuai/kane-cli/node_modules/#{runner_pkg}/bin/v16-runner"


### PR DESCRIPTION
## Symptom

\`brew install kane-cli\` succeeds, but running \`kane-cli\` fails with:

\`\`\`
v16-runner not found. Build the binary with \`cd v16-runner && python build.py\`
or ensure Python is available.
\`\`\`

## Root cause

Inspected the shipped bottle (\`kane-cli-0.2.7.arm64_sequoia.bottle.tar.gz\`):

\`\`\`
libexec/lib/node_modules/@testmuai/kane-cli/        ← main pkg present
libexec/lib/node_modules/@testmuai/kane-cli-darwin-arm64/  ← MISSING
\`\`\`

\`v16-runner\` lives in the platform subpackage (\`@testmuai/kane-cli-darwin-arm64\` etc.), declared via \`optionalDependencies\` in the main pkg's package.json. The brew install never created that directory — the binary isn't anywhere in the cellar.

Why: brew's \`npm install --prefix=#{libexec}\` behaves as a global install, and modern npm versions skip \`optionalDependencies\` in global mode. Additionally brew's \`--ignore-scripts\` flag blocks the platform pkg's postinstall (which chmods the binary executable).

The runtime probe (\`src/runner/spawner.ts\` \`findRunnerExecutable\`) checks \`<main-pkg>/dist/../node_modules/<plat-pkg>/bin/v16-runner\` first — that path doesn't exist, falls through, errors.

## Fix

In \`def install\`, after the main \`npm install\`, explicitly install the matching platform package into the main pkg's nested node_modules, then chmod the binary:

\`\`\`ruby
platform_pkg =
  if OS.mac?
    Hardware::CPU.arm? ? \"@testmuai/kane-cli-darwin-arm64\" : \"@testmuai/kane-cli-darwin-x64\"
  elsif OS.linux?
    \"@testmuai/kane-cli-linux-x64\"
  end

pkg_dir = libexec/\"lib/node_modules/@testmuai/kane-cli\"
cd pkg_dir do
  system \"npm\", \"install\", \"--no-save\",
         \"--cache=#{HOMEBREW_CACHE}/npm_cache\",
         \"#{platform_pkg}@#{version}\"
end
chmod 0755, pkg_dir/\"node_modules/#{platform_pkg}/bin/v16-runner\"
\`\`\`

Picks darwin-arm64 / darwin-x64 / linux-x64 correctly per platform.

## Test block hardened

Adds:

\`\`\`ruby
assert_predicate runner, :exist?
assert_predicate runner, :executable?
\`\`\`

\`kane-cli --version\` is pure JS and was passing the test even with the binary missing. The new assertions would have caught this up-front.

## Bottle block removed

The bottles already published to the \`kane-cli-0.2.7\` release don't contain v16-runner. Removed the \`bottle do\` block from the formula so brew falls back to source build (which now works correctly with the fix).

After merge, manually trigger \"Build bottles\" via \`workflow_dispatch\` to rebuild bottles on the same release tag — the workflow's publish step will re-add the \`bottle do\` block.

## User impact / migration

Users with the broken 0.2.7 bottle already in their cellar:

\`\`\`bash
brew uninstall kane-cli
brew untap LambdaTest/kane
brew install LambdaTest/kane/kane-cli
\`\`\`

(After bottles are rebuilt, the second install pours the working bottle. Before bottles are rebuilt, it falls back to source build via the fixed \`def install\` and ends up correct.)

## Test plan

- [ ] \`ruby -c Formula/kane-cli.rb\` passes (already verified locally)
- [ ] After merge, manual \`workflow_dispatch\` on \"Build bottles\". All 4 matrix entries succeed; the formula \`test\` block (now asserting v16-runner exists + is executable) passes during \`brew install --build-bottle\`.
- [ ] On a clean machine: \`brew install LambdaTest/kane/kane-cli\` then \`kane-cli\` (any subcommand that spawns the runner) — should not throw \"v16-runner not found\".