### PR TITLE
formula: depends_on cask: google-chrome + caveats refresh

### DIFF
--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -25,6 +25,15 @@ class KaneCli < Formula
 
   depends_on "node"
 
+  # Chrome is the runtime browser kane-cli drives. On macOS, brew can
+  # install it directly via the cask so users don't need a separate step.
+  # Linux brew has no cask infrastructure, so Linux users install Chrome
+  # themselves (caveats explain) — kane-cli's runtime gate prints
+  # per-distro instructions if Chrome is missing.
+  on_macos do
+    depends_on cask: "google-chrome"
+  end
+
   def install
     # Strip --build-from-source from std_npm_args (brew/Library/Homebrew/
     # language/node.rb injects it unconditionally). For sharp, that flag
@@ -80,6 +89,13 @@ class KaneCli < Formula
     <<~EOS
       Currently supported platforms: macOS (Apple Silicon and Intel) and Linux x64.
       ARM Linux is not yet available.
+
+      Chrome is required. macOS installs it automatically via the
+      `google-chrome` cask declared above. On Linux, install separately:
+        https://www.google.com/chrome/
+
+      To skip the Chrome check (CI / air-gapped / non-standard install):
+        export KANE_CLI_SKIP_BROWSER_DOWNLOAD=1
     EOS
   end
 


### PR DESCRIPTION
## Summary

Adds Chrome as a brew-managed dependency on macOS via the cask, so `brew install LambdaTest/kane/kane-cli` auto-installs Chrome (no manual step). Refreshes caveats to mention Chrome handling per platform.

Replaces #3, which was branched from a stale main and would have reverted ~7 since-merged fixes (sharp build, bottle pipeline, v16-runner platform-dep install, etc.) plus referenced `KANE_CLI_CHROME_PATH` which was removed upstream as a functional escape hatch.

## Diff (16 +0 / 0 -0 — clean addition)

- `depends_on cask: "google-chrome"` wrapped in `on_macos do ... end` (cask is macOS-only by definition; explicit gating matches Homebrew style guidance).
- Caveats now name:
  - The auto-install via cask on macOS.
  - https://www.google.com/chrome/ for Linux.
  - `KANE_CLI_SKIP_BROWSER_DOWNLOAD=1` as the bypass for CI / air-gapped / non-standard install paths.

The `url` / `sha256` / `version` / `bottle do` / `def install` / `test do` blocks are all untouched. The bottle workflow's auto-managed bits stay intact.

## Pairs with

- [LambdatestIncPrivate/v16#446](https://github.com/LambdatestIncPrivate/v16/pull/446) — runtime Chrome gate (currently merged to `main` + `stage`; `prod` is 4 commits behind so the gate is not yet in any public `@testmuai/kane-cli` release).

## When to merge

This PR is independent of the gate code shipping publicly:

| Order | Outcome |
|---|---|
| Merge before public 0.2.8 ships | Mac users get cask-auto-installed Chrome ✅ but if Chrome is missing/moved, they hit opaque ENOENT (gate not yet in 0.2.7) |
| Merge after public 0.2.8 ships | Cask auto-install + friendly per-platform install message + DD logging on missing Chrome |

Either order is safe — neither breaks anything. Landing it after 0.2.8 means caveats text and runtime behavior are coherent on day one.

## Test plan

- [ ] On a Mac without Chrome: \`brew install LambdaTest/kane/kane-cli\` triggers the cask install, then proceeds with kane-cli install. \`/Applications/Google Chrome.app\` exists after.
- [ ] On a Mac with Chrome already present: cask sees the install satisfied, no re-install.
- [ ] On Linux: \`brew install LambdaTest/kane/kane-cli\` works (no cask attempted), caveats point to chrome.com.
- [ ] \`brew test kane-cli\` still passes (\`--version\` doesn't need Chrome; v16-runner exists/executable assertions added in #10 still hold).