### PR TITLE
fix: drop corrupt arm64_sequoia bottle from 0.2.9

### DIFF
--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -11,9 +11,15 @@ class KaneCli < Formula
 
   bottle do
     root_url "https://github.com/LambdaTest/homebrew-kane/releases/download/kane-cli-0.2.9"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6603d35196a4e7addd5d5b1e79aad6739db9e39f283bca0671e044363e9e89da"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4ec0c15a4806158742a411962bd17e7df7b8b67ff39a2d094f39f4ac397e68a3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a9c1befa4af18bb44ea7b9cef33b66f336a0c377f11ceb9f6302417885f649da"
+    # arm64_sequoia removed: bottle has a real gzip CRC error (`gzip -t`
+    # reports "invalid compressed data--crc error"; tar fails mid-extract
+    # on the v16-runner file). Reproducible across both 0.2.9 builds —
+    # something on the macos-15 GHA runner consistently produces a
+    # corrupt artifact. arm64_sonoma + x86_64_linux are healthy.
+    # Sequoia/Tahoe users now fall back to arm64_sonoma which is fine.
+    # Investigate macos-15 build pipeline before re-adding.
+    sha256 cellar: :any_skip_relocation, arm64_sonoma: "4ec0c15a4806158742a411962bd17e7df7b8b67ff39a2d094f39f4ac397e68a3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "a9c1befa4af18bb44ea7b9cef33b66f336a0c377f11ceb9f6302417885f649da"
   end
 
   # Bottle block intentionally removed — the previously published bottles


### PR DESCRIPTION
## Symptom

\`brew install LambdaTest/kane/kane-cli\` (v0.2.9) on macOS Sequoia / Tahoe arm64 fails:

\`\`\`
gzip decompression failed (zlib returned error -3, msg invalid literal/length/distance code)
tar: Error exit delayed from previous errors.
\`\`\`

## Diagnosis

\`\`\`
$ curl -sLO https://github.com/LambdaTest/homebrew-kane/releases/download/kane-cli-0.2.9/kane-cli-0.2.9.arm64_sequoia.bottle.tar.gz
$ gzip -t kane-cli-0.2.9.arm64_sequoia.bottle.tar.gz
gzip: invalid compressed data--crc error
gzip: kane-cli-0.2.9.arm64_sequoia.bottle.tar.gz: uncompress failed
\`\`\`

The gzip stream itself is corrupt. tar fails partway through extraction (specifically at the v16-runner binary). Same symptom on both 0.2.9 build attempts:

- [Run 25162255363](https://github.com/LambdaTest/homebrew-kane/actions/runs/25162255363) (auto, off 0.2.9 publish) — corrupt
- [Run 25163149794](https://github.com/LambdaTest/homebrew-kane/actions/runs/25163149794) (manual rebuild) — also corrupt

`arm64_sonoma` (built on `macos-14`) and `x86_64_linux` (built on `ubuntu-latest`) from the same runs are healthy.

So it's reproducible on `macos-15` (Sequoia runner) and not on `macos-14` (Sonoma runner). Not transient.

## Stopgap (this PR)

Drop the `arm64_sequoia` entry from the bottle block. Brew falls back to `arm64_sonoma` for Sequoia/Tahoe arm64 users — verified locally that the sonoma bottle extracts cleanly and contains v16-runner at the expected path.

After this merges, the user fix flow is:

\`\`\`
brew uninstall kane-cli
rm -f ~/Library/Caches/Homebrew/downloads/*kane-cli-0.2.9*
brew update
brew install LambdaTest/kane/kane-cli
\`\`\`

(GitHub Releases CDN may also be caching old assets; cache-bust query string downloads work, brew's plain URL hits stale CDN. The cache deletion above forces a fresh fetch.)

## Permanent fix — investigation plan

Something on the GHA `macos-15` runner is consistently producing a corrupt gzip stream when bottling kane-cli. Hypotheses to test:

1. **macos-15 has a buggy `tar` / `gzip`** — version drift on GHA runner image. Check `tar --version` + `gzip --version` in macos-15 vs macos-14 jobs and see if libarchive / GNU gzip versions differ in a way that's caused similar issues elsewhere.
2. **Specific binary content triggers a bug** — the v16-runner darwin-arm64 binary contains data that, combined with a specific compression-buffer size, triggers a known gzip bug. Repro by compressing the binary alone with `gzip` on macos-15 and verifying.
3. **Disk pressure / partial write** — runner runs out of `/tmp` space mid-bottle, partial flush corrupts the trailer. Check disk usage in build log, and also compare bottle sizes (sequoia is 81 MB, sonoma is 81 MB — sizes match, so probably not truncation).
4. **`brew bottle` race condition on macos-15** — known intermittent in some Homebrew versions when running on the most recent macOS image. Check if the action's pinned brew version differs by runner.

Concrete next step:
- Add a **`gzip -t` integrity check step** to `.github/workflows/build-bottles.yml` after the `brew bottle` invocation. Fail the build immediately if the produced bottle is corrupt instead of letting it ship and breaking user installs. That single guard would have caught BOTH 0.2.9 builds before they hit the release.

I'll open a follow-up PR for the integrity check on the workflow.

## Test plan

- [ ] Merge.
- [ ] On a Tahoe/Sequoia arm64 box: `brew uninstall kane-cli; brew install LambdaTest/kane/kane-cli` → expect "Pouring kane-cli-0.2.9.arm64_sonoma.bottle.tar.gz" → install succeeds → kane-cli runs.
- [ ] On macOS Sonoma: same install → expect direct sonoma pour → succeeds.
- [ ] On Linux x64: unchanged, still pours x86_64_linux → succeeds.