### PR TITLE
ci: bottle integrity check + drop macos-15

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -85,10 +85,19 @@ jobs:
         #   arm64_linux   — `@testmuai/kane-cli-linux-arm64` does not exist
         #                   on npm, so there's no platform binary to bundle.
         #                   Out of scope until kane-cli ships that subpackage.
+        # macos-15 (Sequoia) and macos-latest (which currently aliases
+        # macos-15) are dropped: they consistently produce gzip-corrupt
+        # bottles when bottling kane-cli — the resulting tarball fails
+        # `gzip -t` with "invalid compressed data--crc error", so brew
+        # extraction bails mid-stream. Reproducible across multiple
+        # builds (see homebrew-kane#12). macos-14 (Sonoma) is unaffected
+        # and brew's bottle fallback ensures Sequoia/Tahoe users pour
+        # the arm64_sonoma bottle correctly.
+        # TODO: investigate macos-15 corruption — file with GHA runner
+        #   image team if reproducible in isolation. Re-add macos-15 +
+        #   macos-latest once root-caused.
         os:
-          - macos-15
           - macos-14
-          - macos-latest
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -163,6 +172,30 @@ jobs:
           done
 
           ls -la kane-cli-*.bottle.* || true
+
+      - name: Verify bottle integrity
+        # Gate against corrupt bottles before upload. Background:
+        # macos-15 silently produced gzip-CRC-corrupt bottles for kane-cli
+        # 0.2.9 across multiple builds — the bottle file existed at the
+        # right size, the build "succeeded", but `gzip -t` failed and
+        # brew extraction bailed on user machines. This step would have
+        # caught it. See homebrew-kane#12 for the incident.
+        run: |
+          set -e
+          for bottle in kane-cli-*.bottle.tar.gz; do
+            [ -e "$bottle" ] || continue
+            if ! gzip -t "$bottle" 2>&1; then
+              echo "❌ $bottle failed gzip integrity check"
+              exit 1
+            fi
+            # Also verify tar can list contents end-to-end (catches
+            # cases where gzip is fine but tar payload is truncated).
+            if ! tar -tzf "$bottle" >/dev/null 2>&1; then
+              echo "❌ $bottle: gzip OK but tar listing failed"
+              exit 1
+            fi
+            echo "✅ $bottle: gzip + tar listing OK"
+          done
 
       - name: Upload bottle artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Why

Permanent prevention for the corrupt-bottle incident traced in #12. Two parts:

### 1. Integrity check at build time

Adds a `gzip -t` + `tar -tzf` step right after `brew bottle` produces a tarball. Fails the build if the bottle is corrupt — before upload, before release publish, before users hit it.

The 0.2.9 macos-15 bottles slipped through silently:
- File existed at the right size (~81 MB)
- `brew bottle` reported success
- `Detecting if relocatable...` step passed
- Upload succeeded
- Formula's bottle block got the sha256 of the corrupt tarball

…but `gzip -t` would have failed instantly with `invalid compressed data--crc error`. Adding it as a step means future regressions surface in CI, not on user machines.

```yaml
- name: Verify bottle integrity
  run: |
    for bottle in kane-cli-*.bottle.tar.gz; do
      gzip -t "$bottle" || { echo "❌ corrupt"; exit 1; }
      tar -tzf "$bottle" >/dev/null || { echo "❌ tar fails"; exit 1; }
    done
```

Both checks together catch:
- gzip-layer corruption (the 0.2.9 macos-15 case)
- gzip-OK but tar-truncated (catches incomplete uploads / disk pressure)

### 2. Drop macos-15 (and macos-latest) from the matrix

macos-15 reproducibly produces gzip-corrupt bottles when bottling kane-cli. Two consecutive build runs ([25162255363](https://github.com/LambdaTest/homebrew-kane/actions/runs/25162255363) and [25163149794](https://github.com/LambdaTest/homebrew-kane/actions/runs/25163149794)) both produced the same corruption. Build logs are nearly identical to macos-14's, no errors, no warnings — silent corruption.

`macos-latest` currently aliases `macos-15`, so it inherits the bug. Drop both.

Net effect on coverage:

| Before | After |
|---|---|
| arm64_sequoia ❌ corrupt | (removed — fall back to sonoma) |
| arm64_sonoma ✅ healthy | arm64_sonoma ✅ healthy |
| x86_64_linux ✅ healthy | x86_64_linux ✅ healthy |

Brew's bottle-fallback handles Sequoia + Tahoe users correctly via arm64_sonoma — verified end-to-end on Tahoe by extracting + running the sonoma bottle's v16-runner.

### Permanent root-cause investigation (separate work)

Hypotheses for why macos-15 specifically produces corrupt bottles for kane-cli (and not other formulae we know about):

1. **Apple libarchive bug on Sequoia** with specific binary content — kane-cli ships a Nuitka-compiled v16-runner with embedded zlib payloads. Could trigger a known auto-decompression false-positive in libarchive.
2. **GHA macos-15 runner image regression** — image-level tar/gzip drift. Worth comparing `tar --version` / `gzip --version` between macos-14 and macos-15 jobs and seeing if there's a libarchive bump that aligns with the bug appearing.
3. **Buffer/disk pressure** specific to macos-15 runner spec — though sizes match macos-14 (~81 MB) so probably not truncation.

Concrete next step: build the bottle on a macos-15 runner manually, capture `gzip --version` + `tar --version`, compress just the v16-runner binary alone with stock `gzip` and verify integrity. If it reproduces in isolation it's an OS bug; if it only happens via `brew bottle` it's a brew interaction.

I'll open this as a follow-up issue with a repro script after #12 + this PR merge.

## Test plan

- [ ] Merge.
- [ ] Auto-trigger bottle workflow against a future kane-cli version (or manual `workflow_dispatch` for 0.2.9). Expect 2 matrix entries (macos-14, ubuntu-latest), both pass `gzip -t` step, both upload.
- [ ] Verify the formula's bottle block ends up with only `arm64_sonoma` + `x86_64_linux` shas after the workflow's commit-back step.
- [ ] On Tahoe arm64: install pours arm64_sonoma → succeeds.
- [ ] On Sonoma arm64: install pours arm64_sonoma → succeeds.
- [ ] On Linux x64: install pours x86_64_linux → succeeds.

## Pairs with

- #12 — the immediate stopgap that drops the corrupt arm64_sequoia entry from the formula bottle block.