### PR TITLE
ci: grant actions:write so publish dispatches Validate

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -31,6 +31,11 @@ on:
 
 permissions:
   contents: write
+  # Required for the final `gh workflow run "Validate brew install"`
+  # step in the publish job. Without this, gh fails with HTTP 403
+  # "Resource not accessible by integration" — default GITHUB_TOKEN
+  # has only contents permissions in workflow context.
+  actions: write
 
 # Serialize bottle-publish runs so two overlapping invocations can't race
 # each other on the formula commit / release upload. `cancel-in-progress:


### PR DESCRIPTION
## Why

PR #14's chain step (`Trigger Validate brew install with explicit version`) fails with `HTTP 403 Resource not accessible by integration`.

Root cause: default `GITHUB_TOKEN` in workflow context only has `contents: write` scope. Cross-workflow dispatch via `gh workflow run` requires `actions: write`.

Reproduced live: [run 25174137835](https://github.com/LambdaTest/homebrew-kane/actions/runs/25174137835) — guard ✅, matrix builds ✅, integrity check ✅, release upload ✅, formula commit ✅, only the final dispatch step failed.

## Fix

Add `actions: write` to the workflow's top-level permissions block.

```yaml
permissions:
  contents: write
  actions: write
```

That's it.

## Test plan

After merge: re-dispatch Build bottles for 0.2.9. The publish job's final step should successfully `gh workflow run "Validate brew install"` and the chain completes end-to-end.