### PR TITLE
ci: auto-chain Build bottles after formula version bump

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -12,6 +12,10 @@ on:
 
 permissions:
   contents: write
+  # Required for the final step that dispatches Build bottles via
+  # `gh workflow run`. Default GITHUB_TOKEN scope only covers contents
+  # in workflow context.
+  actions: write
 
 jobs:
   update:
@@ -102,11 +106,34 @@ jobs:
           cat "$FORMULA"
 
       - name: Commit and push
+        id: commit
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/kane-cli.rb
-          git diff --cached --quiet && { echo "No changes to commit."; exit 0; }
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git commit -m "Update kane-cli to ${VERSION}"
           git push
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+
+      # Auto-chain Build bottles after the formula bump. Conditional on
+      # an actual commit so re-runs that find no changes don't trigger
+      # spurious bottle builds. The Wait-for-npm step earlier in this
+      # workflow + ~30s of runtime here mean the npm tarball has been
+      # available for ≥1 min before bottling starts; well past npm's
+      # `--min-release-age` threshold that bit kane-cli 0.2.9.
+      - name: Trigger Build bottles for the new version
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh workflow run "Build bottles" \
+            --ref main \
+            -f version="${VERSION}"
+          echo "✅ Dispatched Build bottles for kane-cli ${VERSION}"


### PR DESCRIPTION
## Why

After PR #14 made Build bottles manual-dispatch only, every npm publish needs a release manager to remember to dispatch Build bottles afterwards. With the recent v16 publish cadence (0.2.7 → 0.2.10 in 2 days), that's daily attention.

The reason we made it manual was the 0.2.9 incident: bottling within ~2 min of npm publish raced npm's `--min-release-age` flag and produced silently-broken bottles. This PR re-introduces automation in a way that addresses that root cause.

## What this does

After `Update Homebrew Formula` successfully commits a version bump, the workflow auto-dispatches `Build bottles` via `gh workflow run -f version=$VERSION`.

```yaml
- name: Trigger Build bottles for the new version
  if: steps.commit.outputs.committed == 'true'
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    gh workflow run "Build bottles" \
      --ref main \
      -f version="${{ steps.version.outputs.version }}"
```

## Why this is safer than the original auto-trigger

The 0.2.9 corruption happened because `Build bottles` fired off `Update Homebrew Formula` via `workflow_run` *immediately* after success — within ~2 min of npm publish. By that point npm's `--min-release-age` was still in effect and `npm install` produced a partial install.

This PR's setup buffers that timing organically:

1. v16 publishes npm
2. `Update Homebrew Formula` polls "Wait for npm package availability" — typically 30+ seconds before tarball is consistent
3. Computes sha, updates formula, strips bottle block, commits, pushes
4. Dispatches Build bottles → that workflow's queue + setup adds another ~30s
5. By the time the new `npm install --min-release-age=1` fires, total elapsed since publish is reliably 1+ minute, comfortably past the threshold

Plus, all the Build bottles guards we built in PR #14 still apply: input-vs-formula version check, stale-bottle-block sanity check, integrity check, publish-time re-verify.

## Conditional dispatch

The trigger step uses `if: steps.commit.outputs.committed == 'true'` so re-runs that find nothing to change don't trigger spurious bottle builds. The commit step writes `committed=false` when there are no changes.

## Net release flow after this merges

| Step | Trigger | Manual? |
|---|---|---|
| 1. v16 publishes npm → Update Homebrew Formula | repository_dispatch from v16 | Auto |
| 2. Formula bumped + bottle block stripped | step 1's commit | Auto |
| 3. **Build bottles dispatched for new version** | **step 1's last step** | **Auto (this PR)** |
| 4. Validate brew install | Build bottles' last step (PR #14) | Auto |

Manual `workflow_dispatch` of Build bottles still works for backfill (e.g., re-bottling after an artifact corruption like 0.2.9).

## Test plan

- [ ] After merge, the next v16 npm publish should kick off the full chain end-to-end with no human attention.
- [ ] Manual dispatch of Update Homebrew Formula with a version that's already in the formula → "No changes to commit" → trigger step skipped (no spurious bottle build).

## Pairs with

- #14 — manual trigger + integrity check + chain to Validate
- #15 — actions:write permission (this PR adds the same to update-formula.yml for the same reason)