### PR TITLE
Ensure bottles always contain the v16-runner binary

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -7,19 +7,19 @@ name: Build bottles
 # so user toolchain (Xcode/CLT) version becomes irrelevant.
 #
 # Trigger model:
-#   - `workflow_dispatch` only — manual trigger. After a new npm version
-#     publishes and `Update Homebrew Formula` bumps the formula version,
-#     a release manager dispatches this workflow with the new version
-#     number to produce bottles.
+#   - `workflow_dispatch` — can be triggered manually with a version, and is
+#     ALSO auto-chained by `Update Homebrew Formula` after a version bump
+#     (that workflow runs `gh workflow run "Build bottles"`). So in the normal
+#     release path there is no human in the loop.
 #
 # Why not `workflow_run` after Update Homebrew Formula:
-#   The auto-trigger raced npm publish timing — bottles built within 2
-#   minutes of `npm publish` hit npm's `--min-release-age` threshold and
-#   produced silently-broken installs (kane-cli 0.2.9 incident). Manual
-#   dispatch puts a human in the loop with timing buffer + the chance to
-#   verify the npm tarball is healthy before spending CI cycles bottling
-#   it. The integrity-check step below is a safety net; manual dispatch
-#   is the real prevention.
+#   `workflow_run` raced npm publish timing — bottles built within 2 minutes
+#   of `npm publish` hit npm's `--min-release-age` threshold and produced
+#   silently-broken installs (kane-cli 0.2.9 incident). The auto-chain instead
+#   lives in `update-formula.yml`, whose "Wait for npm package availability"
+#   step now polls the main pkg AND the bottled platform subpackages before
+#   dispatching this workflow — that availability gate, not a human, is the
+#   real prevention. The integrity/content-check step below is the safety net.
 
 on:
   workflow_dispatch:
@@ -226,11 +226,18 @@ jobs:
         # multiple builds (homebrew-kane#12) — file existed at the right
         # size, build "succeeded", upload completed, but `gzip -t` failed
         # and brew extraction bailed on user machines. This step would
-        # have caught it. Two checks:
+        # have caught it. Checks:
         #   1. `gzip -t` — verifies the gzip stream itself
         #   2. `tar -tzf` — verifies tar can list contents end-to-end
         #      (catches truncation where gzip is fine but tar payload is
         #      cut short)
+        #   3. Content check — the v16-runner binary is actually inside the
+        #      bottle, non-trivially sized, and executable. Archive integrity
+        #      (1+2) passes even when the platform npm install produced nothing
+        #      (kane-cli 0.4.6 shipped a 38 MB binary-less arm64 bottle that
+        #      passed gzip/tar but failed `brew install` validation). Extract
+        #      and `find`/`wc -c`/`test -x` rather than parsing `tar -tzvf`
+        #      fields, which differ across BSD (macOS) and GNU (Linux) tar.
         run: |
           set -e
           for bottle in kane-cli-*.bottle.tar.gz; do
@@ -243,7 +250,34 @@ jobs:
               echo "❌ $bottle: gzip OK but tar listing failed"
               exit 1
             fi
-            echo "✅ $bottle: gzip + tar listing OK"
+
+            # Authoritative label->pkg mapping; fail closed on anything
+            # unexpected (a mislabeled bottle must error, not mis-check).
+            case "$bottle" in
+              *.x86_64_linux.bottle.*) PLATFORM_PKG="@testmuai/kane-cli-linux-x64" ;;
+              *.arm64_*.bottle.*)      PLATFORM_PKG="@testmuai/kane-cli-darwin-arm64" ;;
+              *.x86_64_*.bottle.*)     PLATFORM_PKG="@testmuai/kane-cli-darwin-x64" ;;
+              *) echo "❌ $bottle: unrecognized bottle label, cannot verify runner"; exit 1 ;;
+            esac
+            RUNNER_SUFFIX="node_modules/${PLATFORM_PKG}/bin/v16-runner"
+
+            # Extract-all + find: avoids BSD/GNU stored-member-name (./ / dir
+            # prefix) mismatches that selective `tar -x <member>` is prone to.
+            TMP=$(mktemp -d)
+            tar -xzf "$bottle" -C "$TMP"
+            RUNNER=$(find "$TMP" -path "*/${RUNNER_SUFFIX}" -type f | head -1)
+            if [ -z "$RUNNER" ]; then
+              echo "❌ $bottle is missing ${RUNNER_SUFFIX}"; rm -rf "$TMP"; exit 1
+            fi
+            BYTES=$(wc -c < "$RUNNER" | tr -d ' ')
+            if [ "${BYTES:-0}" -lt 1000000 ]; then
+              echo "❌ $bottle: v16-runner present but only ${BYTES} bytes (truncated)"; rm -rf "$TMP"; exit 1
+            fi
+            if [ ! -x "$RUNNER" ]; then
+              echo "❌ $bottle: v16-runner not executable"; rm -rf "$TMP"; exit 1
+            fi
+            rm -rf "$TMP"
+            echo "✅ $bottle: gzip + tar OK, v16-runner present (${BYTES} bytes, executable)"
           done
 
       - name: Upload bottle artifact

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -34,22 +34,39 @@ jobs:
           fi
 
       - name: Wait for npm package availability
+        # Poll the main package AND every platform subpackage that the bottle
+        # matrix builds (macos-14=arm64, ubuntu=x86_64-linux) before this
+        # workflow auto-chains "Build bottles". The platform subpackages are
+        # published separately from the main package and can lag behind on the
+        # registry; if bottling starts before -darwin-arm64 is live, the formula
+        # installs nothing and ships a bottle without v16-runner. We do NOT poll
+        # non-bottled platforms (e.g. -darwin-x64) — a late one there must not
+        # block the release; its absence only matters on a source-build, which
+        # the formula's own install guard handles.
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          PKG="@testmuai/kane-cli"
-          echo "Waiting for ${PKG}@${VERSION} on npmjs.com..."
-          for i in $(seq 1 24); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-              "https://registry.npmjs.org/${PKG}/${VERSION}")
-            if [ "$STATUS" = "200" ]; then
-              echo "${PKG}@${VERSION} is available."
-              exit 0
+          PKGS="@testmuai/kane-cli \
+                @testmuai/kane-cli-darwin-arm64 \
+                @testmuai/kane-cli-linux-x64"
+          for PKG in $PKGS; do
+            echo "Waiting for ${PKG}@${VERSION} on npmjs.com..."
+            FOUND=""
+            for i in $(seq 1 24); do
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                "https://registry.npmjs.org/${PKG}/${VERSION}")
+              if [ "$STATUS" = "200" ]; then
+                echo "${PKG}@${VERSION} is available."
+                FOUND="yes"
+                break
+              fi
+              echo "Poll ${i}/24 — HTTP ${STATUS}, sleeping 5s..."
+              sleep 5
+            done
+            if [ -z "$FOUND" ]; then
+              echo "ERROR: ${PKG}@${VERSION} not visible on npmjs.com after 2m"
+              exit 1
             fi
-            echo "Poll ${i}/24 — HTTP ${STATUS}, sleeping 5s..."
-            sleep 5
           done
-          echo "ERROR: ${PKG}@${VERSION} not visible on npmjs.com after 2m"
-          exit 1
 
       - name: Compute tarball sha256
         id: tarball

--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -58,19 +58,43 @@ class KaneCli < Formula
     odie "kane-cli does not yet ship a v16-runner binary for this platform." if platform_pkg.nil?
 
     pkg_dir = libexec/"lib/node_modules/@testmuai/kane-cli"
-    cd pkg_dir do
-      # Mirror brew's tightened npm flags (--ignore-scripts, --audit/fund off)
-      # so this second install matches the security/sandbox stance of the
-      # first. We chmod the binary ourselves below, so blocking the pkg's
-      # postinstall is fine.
-      system "npm", "install", "--no-save",
-             "--ignore-scripts", "--audit=false", "--fund=false",
-             "--loglevel=error",
-             "--cache=#{HOMEBREW_CACHE}/npm_cache",
-             "#{platform_pkg}@#{version}"
-    end
     runner = pkg_dir/"node_modules/#{platform_pkg}/bin/v16-runner"
-    chmod 0755, runner if runner.exist?
+    cd pkg_dir do
+      # Retry the platform install with backoff: the subpackage is published
+      # separately from the main pkg and can lag behind on the npm registry,
+      # so a fresh version may 404 / install nothing on the first try. Use
+      # quiet_system (NOT system) so a nonzero exit doesn't raise and abort
+      # before the later backoff attempts run. --prefer-online forces a real
+      # re-fetch instead of replaying a stale/negative cache entry. Mirror
+      # brew's tightened npm flags; we chmod the binary ourselves below.
+      [0, 15, 45].each do |backoff|
+        sleep backoff if backoff.positive?
+        quiet_system "npm", "install", "--no-save",
+                     "--ignore-scripts", "--audit=false", "--fund=false",
+                     "--loglevel=error", "--prefer-online",
+                     "--cache=#{HOMEBREW_CACHE}/npm_cache",
+                     "#{platform_pkg}@#{version}"
+        break if runner.exist? && runner.size > 1_000_000
+      end
+    end
+
+    # The runner must exist AND be a real (multi-MB) binary — a present but
+    # empty/truncated file is the silent-broken-bottle failure mode. On CI /
+    # bottle builds, fail hard so a broken bottle can never build green. On a
+    # user source-build, warn but complete (the JS CLI still works; only
+    # `kane-cli run` needs the runner) rather than rolling back the install.
+    if runner.exist? && runner.size > 1_000_000
+      chmod 0755, runner
+    else
+      msg = "v16-runner missing or truncated after installing #{platform_pkg}@#{version} " \
+            "(found: #{runner.exist? ? "#{runner.size} bytes" : "absent"})"
+      if ENV["CI"] || ENV["HOMEBREW_BUILD_BOTTLE"]
+        odie msg
+      else
+        opoo "#{msg}. kane-cli is installed but `kane-cli run` will not work until the " \
+             "platform package is available on npm — re-run `brew reinstall kane-cli` later."
+      end
+    end
 
     bin.install_symlink libexec.glob("bin/*")
   end

--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -15,13 +15,6 @@ class KaneCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "9cbf66acfddda86d5583d6baaf2bda18c98f7f9def4e4c8d0dda35dbfd8092a2"
   end
 
-  # Bottle block intentionally removed — the previously published bottles
-  # ship without the v16-runner binary (platform optional dep was missing
-  # from the brew install). The `.github/workflows/build-bottles.yml`
-  # pipeline rebuilds bottles and rewrites this block when re-run after
-  # this fix lands. Until then brew falls back to source build, which is
-  # correct with the install changes below.
-
   depends_on "node"
 
   def install


### PR DESCRIPTION
## Problem

A bottle can build, pass integrity checks, and upload **green while missing the platform `v16-runner` binary**. Two gaps combine:

1. The formula's platform `npm install` (`@testmuai/kane-cli-<plat>`) can **exit 0 yet install nothing** when that platform subpackage hasn't finished propagating to the npm registry — it's published separately from the main package.
2. Nothing downstream checked bottle **contents** — only gzip/tar validity. The existing `chmod … if runner.exist?` silently skipped, and the formula's `test do` runner assertion doesn't run during `brew install --build-bottle`.

The result is a bottle that installs cleanly but where `kane-cli run` fails at runtime because the runner binary isn't there. It was only caught post-publish by the validate workflow.

## Fix (defense in depth)

**`update-formula.yml`** — the "Wait for npm package availability" step now polls the **bottled platform subpackages** (`-darwin-arm64`, `-linux-x64`) in addition to the main package before it auto-triggers Build bottles, so bottling can't start while the binary the formula installs is still propagating. Non-bottled platforms are intentionally not polled so a late one there can't block a release.

**`Formula/kane-cli.rb`** — the platform install now runs in a `[0, 15, 45]s` backoff loop using `quiet_system` (so a transient failure doesn't raise and abort before the retries) with `--prefer-online`, then asserts the runner exists and is a real (>1 MB) binary:
- on CI / bottle builds → hard-fail, so a broken bottle can never build green;
- on a user source-build → warn and continue (the JS CLI still works; only `kane-cli run` needs the runner) instead of rolling back the install.

**`build-bottles.yml`** — the integrity step now **extracts the built bottle and verifies the runner is present, non-trivially sized, and executable** before upload, using a portable extract + `find` + `wc -c` + `test -x` (no `tar -tzvf` field parsing, which differs across BSD/GNU tar).

## Testing

- `ruby -c` on the formula and YAML parse on both workflows pass.
- `brew style Formula/kane-cli.rb` is clean for the changed code.
- Not yet exercised end-to-end in CI — recommend a Build bottles dispatch + Validate run on a real version before merge.
