### PR TITLE
fix: bottle the checked-out formula version, not a stale tap

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -182,6 +182,15 @@ jobs:
       - name: Tap self into Homebrew
         run: |
           TAP_DIR="$(brew --repository)/Library/Taps/lambdatest/homebrew-kane"
+          # `setup-homebrew` pre-taps this repo using the tap's JSON API index,
+          # which can lag a brand-new release commit by a minute or so. That
+          # leaves TAP_DIR as a real directory checked out at the PREVIOUS
+          # version. `ln -snf SRC DIR` into an existing real directory nests the
+          # symlink inside it instead of replacing it, so brew would keep
+          # resolving the stale formula and bottle the wrong version. Remove any
+          # pre-tapped directory first so the symlink to this freshly
+          # checked-out workspace is the authoritative tap.
+          rm -rf "$TAP_DIR"
           mkdir -p "$(dirname "$TAP_DIR")"
           ln -snf "$GITHUB_WORKSPACE" "$TAP_DIR"
           brew tap | grep lambdatest/kane
@@ -205,6 +214,20 @@ jobs:
           ROOT_URL="https://github.com/LambdaTest/homebrew-kane/releases/download/kane-cli-${VERSION}"
 
           brew install --build-bottle lambdatest/kane/kane-cli
+
+          # Version-drift guard: brew must have bottled the version `guard`
+          # resolved from the checked-out formula. If the tap resolved a stale
+          # formula, the Cellar version won't match VERSION, and the bottle
+          # filenames would later fail the publish glob with a confusing
+          # "No bottle artifacts found". Fail here instead, with the real cause.
+          INSTALLED=$(ls "$(brew --cellar kane-cli)")
+          if [ "$INSTALLED" != "$VERSION" ]; then
+            echo "❌ Built kane-cli ${INSTALLED} but this run is for ${VERSION}."
+            echo "   The local tap did not resolve the checked-out formula"
+            echo "   (stale tap/formula). Aborting before producing mismatched bottles."
+            exit 1
+          fi
+
           brew bottle \
             --no-rebuild \
             --json \

--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -217,12 +217,14 @@ jobs:
 
           # Version-drift guard: brew must have bottled the version `guard`
           # resolved from the checked-out formula. If the tap resolved a stale
-          # formula, the Cellar version won't match VERSION, and the bottle
+          # formula, the expected Cellar version dir won't exist, and the bottle
           # filenames would later fail the publish glob with a confusing
           # "No bottle artifacts found". Fail here instead, with the real cause.
-          INSTALLED=$(ls "$(brew --cellar kane-cli)")
-          if [ "$INSTALLED" != "$VERSION" ]; then
-            echo "❌ Built kane-cli ${INSTALLED} but this run is for ${VERSION}."
+          # Check for the expected version dir directly (not `ls`-equality) so a
+          # future `revision` or a multi-version Cellar can't false-fail it.
+          if [ ! -d "$(brew --cellar kane-cli)/$VERSION" ]; then
+            echo "❌ Expected kane-cli ${VERSION} in the Cellar, but it is not there:"
+            ls -1 "$(brew --cellar kane-cli)" 2>/dev/null || true
             echo "   The local tap did not resolve the checked-out formula"
             echo "   (stale tap/formula). Aborting before producing mismatched bottles."
             exit 1


### PR DESCRIPTION
## Problem

A `Build bottles` run produced bottles for the **previous** version and the
`publish` job aborted with **"No bottle artifacts found."** Both build legs were
green and the bottles were valid — just the wrong version.

Trace:
- `guard` resolved the run version from the checked-out formula (e.g. the new
  release), and `publish` later globbed `bottles/kane-cli-<new>.*` — empty.
- The `build` job checked out the **correct** new-release commit, but
  `brew install --build-bottle` resolved the **previous** formula version and
  bottled that.

## Root cause

`setup-homebrew` pre-taps this repo through the tap's **JSON API index**, which
can lag a just-pushed release commit by ~a minute. That leaves the tap directory
checked out at the previous version. The `Tap self into Homebrew` step then ran:

```bash
ln -snf "$GITHUB_WORKSPACE" "$TAP_DIR"
```

Because `$TAP_DIR` already existed as a **real directory** (the pre-tapped copy),
`ln -snf` **nested the symlink inside it** instead of replacing it. So `brew`
kept resolving the stale formula and bottled the previous version, while `guard`
and `publish` read the version straight from the freshly checked-out `.rb`.
Hence the mismatch.

This is timing-dependent (it triggers when bottling starts within ~a minute of
the release commit), which is why it surfaces intermittently after back-to-back
releases.

## Fix

1. **Tap self** — `rm -rf "$TAP_DIR"` before the symlink, so the freshly
   checked-out workspace is the authoritative tap and `brew` always resolves the
   formula this run checked out.
2. **Build bottle** — assert the installed Cellar version equals the run's
   version and fail loudly at build time if it drifted, instead of letting it
   surface three jobs later as a confusing publish-time glob miss.

## Notes

No behavior change on the happy path. The version assertion only fires when the
tap resolves a stale formula — turning a silent wrong-version build into an
actionable failure at the point it happens.
