### PR TITLE
fix(ci): close the npm-propagation race that ships binary-less bottle installs

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -213,7 +213,30 @@ jobs:
           VERSION="${{ needs.guard.outputs.version }}"
           ROOT_URL="https://github.com/LambdaTest/homebrew-kane/releases/download/kane-cli-${VERSION}"
 
-          brew install --build-bottle lambdatest/kane/kane-cli
+          # Bounded retry around the install. The formula's npm install treats
+          # platform packages as OPTIONAL deps: minutes after `npm publish`, a
+          # CDN edge that can't serve the fresh .tgz yet makes npm silently
+          # SKIP the package, and the formula's content check then aborts with
+          # "v16-runner (absent)" (0.6.2: run 29539227276; 0.2.9 incident was
+          # the same class). update-formula's availability gate now verifies
+          # tarball bytes before dispatching, but it fetches from a DIFFERENT
+          # runner/edge than this job — the authoritative retry lives here.
+          # Real formula bugs (e.g. agentless 0.6.0 packages) still fail: they
+          # fail identically on all three attempts.
+          INSTALL_OK=""
+          for attempt in 1 2 3; do
+            if brew install --build-bottle lambdatest/kane/kane-cli; then
+              INSTALL_OK="yes"
+              break
+            fi
+            echo "brew install attempt ${attempt}/3 failed — cleaning up and retrying in 90s (npm CDN propagation is the usual transient cause)..."
+            brew uninstall --force kane-cli 2>/dev/null || true
+            sleep 90
+          done
+          if [ -z "$INSTALL_OK" ]; then
+            echo "❌ brew install --build-bottle failed on all 3 attempts — not a propagation blip; see the last npm output above."
+            exit 1
+          fi
 
           # Version-drift guard: brew must have bottled the version `guard`
           # resolved from the checked-out formula. If the tap resolved a stale

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -43,6 +43,15 @@ jobs:
         # non-bottled platforms (e.g. -darwin-x64) — a late one there must not
         # block the release; its absence only matters on a source-build, which
         # the formula's own install guard handles.
+        #
+        # TWO stages: metadata visibility, then the actual tarball BYTES.
+        # A version document going 200 does not mean every CDN edge can serve
+        # the .tgz yet — and npm treats the platform packages as OPTIONAL
+        # deps, so a failed tarball fetch is silently SKIPPED rather than
+        # fatal. That is exactly how the 0.6.2 bottle build installed a
+        # kane-cli without v16-runner/assurance-agent and died in the
+        # formula's content check (run 29539227276; same class as the 0.2.9
+        # incident). Gate the dispatch on a clean end-to-end fetch instead.
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           PKGS="@testmuai/kane-cli \
@@ -64,6 +73,30 @@ jobs:
             done
             if [ -z "$FOUND" ]; then
               echo "ERROR: ${PKG}@${VERSION} not visible on npmjs.com after 2m"
+              exit 1
+            fi
+          done
+
+          # Stage 2: the bytes. Full fetch + gzip integrity per package —
+          # what `npm install` will actually need, not just the metadata.
+          for PKG in $PKGS; do
+            TARBALL=$(curl -fsSL "https://registry.npmjs.org/${PKG}/${VERSION}" | jq -r '.dist.tarball')
+            if [ -z "$TARBALL" ] || [ "$TARBALL" = "null" ]; then
+              echo "ERROR: could not resolve dist.tarball for ${PKG}@${VERSION}"
+              exit 1
+            fi
+            OK=""
+            for i in $(seq 1 8); do
+              if curl -fsSL "$TARBALL" | gzip -t 2>/dev/null; then
+                echo "${PKG}@${VERSION} tarball fetches clean end-to-end."
+                OK="yes"
+                break
+              fi
+              echo "Tarball poll ${i}/8 — ${PKG}@${VERSION} not cleanly fetchable yet, sleeping 15s..."
+              sleep 15
+            done
+            if [ -z "$OK" ]; then
+              echo "ERROR: ${PKG}@${VERSION} tarball not cleanly fetchable after ~2m — not dispatching the bottle build."
               exit 1
             fi
           done


### PR DESCRIPTION
## What

Two layered fixes for the recurring "bottle build fails right after a release" flake:

1. **`update-formula.yml` — gate the bottle dispatch on tarball BYTES, not metadata.** The availability wait only polled `registry.npmjs.org/<pkg>/<version>` for HTTP 200; the version document goes live before every CDN edge can serve the `.tgz`. Stage 2 now resolves each bottled package's `dist.tarball` and requires a clean end-to-end fetch (`curl | gzip -t`) with its own retry window before `Build bottles` is dispatched.
2. **`build-bottles.yml` — bounded retry around `brew install --build-bottle`** (3 attempts, 90s apart, `brew uninstall --force` between). The gate and the build run on different runners/edges, so the authoritative retry belongs with the consumer.

## Why (evidence)

- **kane-cli 0.6.2, run [29539227276](https://github.com/LambdaTest/homebrew-kane/actions/runs/29539227276)**: bottle build started 8s after the formula update, `npm install` ran ~3.5 min after the darwin-arm64 publish (22:17:34Z → 22:21:20Z), and the formula's content check aborted with `v16-runner (absent), assurance-agent (absent)`.
- The published tarball is **provably intact** — downloading `@testmuai/kane-cli-darwin-arm64@0.6.2` shows both binaries (73 MB v16-runner + 21 MB assurance-agent). npm treats the platform packages as **optionalDependencies, which fail soft**: an edge that can't serve the fresh tarball makes npm silently skip the package instead of erroring. Same class as the 0.2.9 incident already documented in the workflow header.
- The identical-looking failure earlier that day ([29475645442](https://github.com/LambdaTest/homebrew-kane/actions/runs/29475645442)) was actually the gate working correctly on genuinely agentless 0.6.0 packages — the retry does NOT mask that class: a real packaging bug fails identically on all 3 attempts and the content check stays authoritative.

## Validation

- `actionlint` clean on both files; `bash -n` on both changed `run:` blocks.
- Stage-2 logic executed as-is against the live registry for all three 0.6.2 packages — resolves `dist.tarball` and passes `gzip -t` end-to-end.

## Note

This prevents recurrence; it does not backfill the missing 0.6.2 bottles. A manual `Build bottles` re-dispatch (blank version) is still needed for 0.6.2 — the packages are >14h old now, so it will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)