### PR TITLE
formula: install the split kane-cli-assurance package

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -43,28 +43,38 @@ jobs:
         # non-bottled platforms (e.g. -darwin-x64) — a late one there must not
         # block the release; its absence only matters on a source-build, which
         # the formula's own install guard handles.
+        #
+        # Post-split releases ship the assurance-agent in its own
+        # kane-cli-assurance-<platform> package — poll it for the bottled
+        # platforms too, but only when the meta's optionalDependencies list
+        # it, so re-dispatching an older (pre-split) version stays valid.
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          PKGS="@testmuai/kane-cli \
-                @testmuai/kane-cli-darwin-arm64 \
-                @testmuai/kane-cli-linux-x64"
-          for PKG in $PKGS; do
+          poll() {
+            local PKG="$1"
             echo "Waiting for ${PKG}@${VERSION} on npmjs.com..."
-            FOUND=""
             for i in $(seq 1 24); do
               STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
                 "https://registry.npmjs.org/${PKG}/${VERSION}")
               if [ "$STATUS" = "200" ]; then
                 echo "${PKG}@${VERSION} is available."
-                FOUND="yes"
-                break
+                return 0
               fi
               echo "Poll ${i}/24 — HTTP ${STATUS}, sleeping 5s..."
               sleep 5
             done
-            if [ -z "$FOUND" ]; then
-              echo "ERROR: ${PKG}@${VERSION} not visible on npmjs.com after 2m"
-              exit 1
+            echo "ERROR: ${PKG}@${VERSION} not visible on npmjs.com after 2m"
+            return 1
+          }
+          poll "@testmuai/kane-cli"
+          META=$(curl -fsSL "https://registry.npmjs.org/@testmuai/kane-cli/${VERSION}")
+          for P in darwin-arm64 linux-x64; do
+            poll "@testmuai/kane-cli-${P}"
+            if echo "$META" | jq -e --arg d "@testmuai/kane-cli-assurance-${P}" \
+                 '.optionalDependencies[$d] // empty' >/dev/null; then
+              poll "@testmuai/kane-cli-assurance-${P}"
+            else
+              echo "meta lists no @testmuai/kane-cli-assurance-${P} — pre-split release, not polled."
             fi
           done
 

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -54,8 +54,13 @@ jobs:
             local PKG="$1"
             echo "Waiting for ${PKG}@${VERSION} on npmjs.com..."
             for i in $(seq 1 24); do
+              # `|| true`: under the step's `set -e` a transient DNS/TLS/
+              # timeout error would otherwise kill the step on the spot —
+              # it must count as a failed poll (curl still emits 000) so
+              # the retry loop actually retries.
               STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-                "https://registry.npmjs.org/${PKG}/${VERSION}")
+                --connect-timeout 5 --max-time 20 \
+                "https://registry.npmjs.org/${PKG}/${VERSION}" || true)
               if [ "$STATUS" = "200" ]; then
                 echo "${PKG}@${VERSION} is available."
                 return 0
@@ -70,11 +75,20 @@ jobs:
           META=$(curl -fsSL "https://registry.npmjs.org/@testmuai/kane-cli/${VERSION}")
           for P in darwin-arm64 linux-x64; do
             poll "@testmuai/kane-cli-${P}"
-            if echo "$META" | jq -e --arg d "@testmuai/kane-cli-assurance-${P}" \
-                 '.optionalDependencies[$d] // empty' >/dev/null; then
+            # jq -e exits 0 when the dep is present, 1/4 when genuinely
+            # absent (pre-split release). Anything else means the meta
+            # response was not the JSON we expect — fail closed instead of
+            # misreading garbage as pre-split and skipping the poll.
+            RC=0
+            echo "$META" | jq -e --arg d "@testmuai/kane-cli-assurance-${P}" \
+              '.optionalDependencies[$d] // empty' >/dev/null || RC=$?
+            if [ "$RC" -eq 0 ]; then
               poll "@testmuai/kane-cli-assurance-${P}"
-            else
+            elif [ "$RC" -eq 1 ] || [ "$RC" -eq 4 ]; then
               echo "meta lists no @testmuai/kane-cli-assurance-${P} — pre-split release, not polled."
+            else
+              echo "ERROR: could not parse the registry meta for ${VERSION} (jq exit ${RC})"
+              exit 1
             fi
           done
 

--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -27,14 +27,22 @@ class KaneCli < Formula
     # subpackages are missing after the main install — kane-cli then can't
     # find its binaries at runtime.
     #
-    # Since the node-split release the binaries live in TWO packages:
-    #   @testmuai/kane-cli-<plat>       -> v16-runner + assurance-agent,
-    #                                      versioned with the CLI
-    #   @testmuai/kane-cli-node-<plat>  -> the bundled Node runtime,
-    #                                      versioned by the NODE PIN (e.g.
-    #                                      24.18.0) and reused across CLI
-    #                                      releases until the pin moves
-    # Install both explicitly into the main package's nested node_modules so
+    # Since the node-split release the binaries live in separate packages:
+    #   @testmuai/kane-cli-<plat>            -> v16-runner, versioned with
+    #                                           the CLI
+    #   @testmuai/kane-cli-assurance-<plat>  -> assurance-agent, versioned
+    #                                           with the CLI (split out of
+    #                                           the platform package when the
+    #                                           combined tarball outgrew
+    #                                           npm's publish size cap;
+    #                                           pre-split releases ship it
+    #                                           inside the platform package)
+    #   @testmuai/kane-cli-node-<plat>       -> the bundled Node runtime,
+    #                                           versioned by the NODE PIN
+    #                                           (e.g. 24.18.0) and reused
+    #                                           across CLI releases until
+    #                                           the pin moves
+    # Install them explicitly into the main package's nested node_modules so
     # the runtime resolver finds them via the first probed path. brew's
     # --ignore-scripts also blocks the packages' postinstall (which chmods
     # the binaries), so chmod here ourselves.
@@ -60,12 +68,20 @@ class KaneCli < Formula
     # optionalDependencies — read it from the installed meta, never hardcode
     # a Node version here (the pin outlives CLI releases and moves on its
     # own cadence).
-    node_pkg_version = JSON.parse((pkg_dir/"package.json").read)
-                           .dig("optionalDependencies", node_pkg)
+    meta = JSON.parse((pkg_dir/"package.json").read)
+    node_pkg_version = meta.dig("optionalDependencies", node_pkg)
     if node_pkg_version.nil?
       odie "#{node_pkg} is not in the meta's optionalDependencies — " \
            "this formula requires a node-split kane-cli release (>= 0.6.6)."
     end
+
+    # Layout discovery, not a version cutoff: a meta that lists the assurance
+    # package in optionalDependencies is a post-split release (agent in its
+    # own package); one that doesn't is pre-split (agent inside the platform
+    # package). Both install correctly from this formula.
+    assurance_pkg = platform_pkg.sub("kane-cli-", "kane-cli-assurance-")
+    assurance_pkg_version = meta.dig("optionalDependencies", assurance_pkg)
+    agent_pkg = assurance_pkg_version ? assurance_pkg : platform_pkg
 
     # kane-cli needs every binary across both packages: v16-runner drives the
     # browser, assurance-agent backs AI test authoring, and node is the
@@ -74,9 +90,12 @@ class KaneCli < Formula
     # missing unnoticed.
     binaries = {
       "v16-runner"      => pkg_dir/"node_modules/#{platform_pkg}/bin/v16-runner",
-      "assurance-agent" => pkg_dir/"node_modules/#{platform_pkg}/bin/assurance-agent",
+      "assurance-agent" => pkg_dir/"node_modules/#{agent_pkg}/bin/assurance-agent",
       "node"            => pkg_dir/"node_modules/#{node_pkg}/bin/node",
     }
+
+    install_specs = ["#{platform_pkg}@#{version}", "#{node_pkg}@#{node_pkg_version}"]
+    install_specs << "#{assurance_pkg}@#{assurance_pkg_version}" if assurance_pkg_version
 
     # A binary counts as installed only if it exists AND is a real (multi-MB)
     # file — a present but empty/truncated one is the silent-broken-bottle mode.
@@ -98,7 +117,7 @@ class KaneCli < Formula
                      "--ignore-scripts", "--audit=false", "--fund=false",
                      "--loglevel=error", "--prefer-online",
                      "--cache=#{HOMEBREW_CACHE}/npm_cache",
-                     "#{platform_pkg}@#{version}", "#{node_pkg}@#{node_pkg_version}"
+                     *install_specs
         # Retry until EVERY binary landed — breaking as soon as one is present
         # would let a half-installed package look complete and stop retrying.
         break if complete.call
@@ -113,8 +132,8 @@ class KaneCli < Formula
     else
       missing = binaries.reject { |_, path| path.exist? && path.size > 1_000_000 }
                         .map { |name, path| "#{name} (#{path.exist? ? "#{path.size} bytes" : "absent"})" }
-      msg = "missing or truncated after installing #{platform_pkg}@#{version} + " \
-            "#{node_pkg}@#{node_pkg_version}: #{missing.join(", ")}"
+      msg = "missing or truncated after installing #{install_specs.join(" + ")}: " \
+            "#{missing.join(", ")}"
       if ENV["CI"] || ENV["HOMEBREW_BUILD_BOTTLE"]
         odie msg
       else
@@ -150,14 +169,19 @@ class KaneCli < Formula
       end
     node_pkg = runner_pkg.sub("kane-cli-", "kane-cli-node-")
     meta_root = libexec/"lib/node_modules/@testmuai/kane-cli"
+    # Same layout discovery as def install: post-split metas list the
+    # assurance package in optionalDependencies; pre-split releases carry the
+    # agent inside the platform package.
+    assurance_pkg = runner_pkg.sub("kane-cli-", "kane-cli-assurance-")
+    meta = JSON.parse((meta_root/"package.json").read)
+    agent_pkg = meta.dig("optionalDependencies", assurance_pkg) ? assurance_pkg : runner_pkg
     pkg_root = meta_root/"node_modules/#{runner_pkg}"
+    agent_root = meta_root/"node_modules/#{agent_pkg}"
     node_root = meta_root/"node_modules/#{node_pkg}"
-    { pkg_root => ["v16-runner", "assurance-agent"], node_root => ["node"] }.each do |root, names|
-      names.each do |name|
-        binary = root/"bin"/name
-        assert_predicate binary, :exist?, "#{name} binary missing — #{root.basename} not installed"
-        assert_predicate binary, :executable?, "#{name} not executable — install-time chmod missed"
-      end
+    [[pkg_root, "v16-runner"], [agent_root, "assurance-agent"], [node_root, "node"]].each do |root, name|
+      binary = root/"bin"/name
+      assert_path_exists binary, "#{name} binary missing — #{root.basename} not installed"
+      assert_predicate binary, :executable?, "#{name} not executable — install-time chmod missed"
     end
     # The bundled runtime must be exactly the version the node package was
     # built with — read the stamp (it lives in the NODE package since the


### PR DESCRIPTION
## Why

kane-cli releases after the assurance split ship the assurance-agent binary in its own npm package (`@testmuai/kane-cli-assurance-<platform>`) instead of inside `@testmuai/kane-cli-<platform>`. Homebrew's prefix-mode `npm install` skips `optionalDependencies`, so the formula must install binary subpackages explicitly — without this change, installing a post-split release completes with no assurance-agent (source builds warn, bottle builds fail).

## What

- `Formula/kane-cli.rb` discovers the layout from the installed meta's `optionalDependencies` (the same pattern already used for the node runtime package): metas that list the assurance package install and assert it at its own path; pre-split metas keep the legacy in-platform-package path. One formula handles both, so this can merge ahead of the first split release — the currently pinned 0.7.2 installs unchanged.
- `.github/workflows/update-formula.yml` also polls the assurance packages for the bottled platforms before chaining Build bottles, gated on the meta's `optionalDependencies` so re-dispatching a pre-split version stays valid. The poll is hardened while here: curl transport failures count as a failed attempt instead of aborting the step under `set -e` (with connect/max timeouts so a stalled request cannot eat the polling window), and an unparseable meta response fails closed instead of being read as pre-split.

## Verification

- `ruby -c` and `brew style` clean (net fewer offenses than the current formula).
- Layout discovery exercised against the published `@testmuai/kane-cli@0.7.2` meta (legacy path chosen, no assurance install attempted) and a post-split meta (assurance package added to the install specs and asserted at its own path).
- Poll behavior probed under `bash -e`: transport failures retry through the full window and then fail the step; the jq gate polls on post-split metas, skips on genuine pre-split metas, and hard-fails on a malformed response.